### PR TITLE
Move secrets to AWS Secrets Manager with caching

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,14 +100,16 @@ provider:
           Action:
             - cloudwatch:PutMetricData
           Resource: '*'
+        - Effect: Allow
+          Action:
+            - secretsmanager:GetSecretValue
+          Resource:
+            - arn:aws:secretsmanager:${aws:region}:${aws:accountId}:secret:stripedshield/prod/*
   environment:
     # Environment variables - PRODUCTION from SSM
-    STRIPE_SECRET: ${ssm:/stripedshield/prod/STRIPE_SECRET~true}
     STRIPE_CLIENT_ID: ${ssm:/stripedshield/prod/STRIPE_CLIENT_ID~true}
     STRIPE_REDIRECT_URI: https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/auth/stripe/callback
-    STRIPE_CONNECT_WEBHOOK_SECRET: ${ssm:/stripedshield/prod/STRIPE_WEBHOOK_SECRET~true}
-    OPENAI_API_KEY: ${ssm:/stripedshield/prod/OPENAI_API_KEY~true}
-    SERVICE_KEY: ${ssm:/stripedshield/prod/SERVICE_KEY~true}
+    SECRETS_MANAGER_PREFIX: stripedshield/prod
     # AWS Resources
     EVIDENCE_BUCKET: arn:aws:s3:::${sls:stage}-${self:service}-evidence-${aws:accountId}
     CASES_TABLE: !Ref CasesTable
@@ -117,7 +119,6 @@ provider:
     # Redis - Use SSM if available, otherwise default endpoint
     REDIS_URL: ${ssm:/stripedshield/prod/REDIS_URL, 'redis://stripedshield-redis.mot6cw.0001.use1.cache.amazonaws.com:6379'}
     # Firebase Configuration
-    FIREBASE_SERVICE_ACCOUNT: ${ssm:/stripedshield/prod/FIREBASE_SERVICE_ACCOUNT~true, ''}
     FIREBASE_PROJECT_ID: ${ssm:/stripedshield/prod/FIREBASE_PROJECT_ID, 'stripecharge-b27a6'}
     # AI Settings
     AI_ENABLED: 'true'

--- a/src/ai/disputeAnalyzer.ts
+++ b/src/ai/disputeAnalyzer.ts
@@ -1,10 +1,5 @@
-import OpenAI from 'openai';
 import Stripe from 'stripe';
-
-// Initialize clients
-const openai = process.env.OPENAI_API_KEY 
-  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-  : null;
+import { getOpenAIClient } from '../shared/openaiClient';
 
 const MODEL = process.env.AI_MODEL || 'gpt-5';
 
@@ -31,8 +26,9 @@ export type AnalysisInput = {
  */
 export async function analyze(input: AnalysisInput): Promise<DisputeAnalysis> {
   const { dispute, charge, customer, history = [], priorDisputes = 0, merchantWinRate } = input;
-  
+
   // If AI not configured, use rule-based analysis
+  const openai = await getOpenAIClient();
   if (!openai) {
     return ruleBasedAnalysis(input);
   }

--- a/src/ai/narrativeWriter.ts
+++ b/src/ai/narrativeWriter.ts
@@ -1,10 +1,5 @@
-import OpenAI from 'openai';
 import type { EvidenceBundle } from './smartEvidenceCollector';
-
-// Initialize OpenAI client
-const openai = process.env.OPENAI_API_KEY 
-  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-  : null;
+import { getOpenAIClient } from '../shared/openaiClient';
 
 // Use GPT-5 Exclusive
 const MODEL = process.env.AI_MODEL || 'gpt-5';
@@ -22,9 +17,10 @@ export type NarrativeOptions = {
  * Professional tone optimized for card network reviewers
  */
 export async function compose(
-  bundle: EvidenceBundle, 
+  bundle: EvidenceBundle,
   options: NarrativeOptions = {}
 ): Promise<string | undefined> {
+  const openai = await getOpenAIClient();
   if (!openai) {
     console.warn('[narrativeWriter] OpenAI not configured, skipping narrative generation');
     return undefined;
@@ -291,6 +287,7 @@ export async function enhance(
   existingNarrative: string,
   additionalContext: string
 ): Promise<string | undefined> {
+  const openai = await getOpenAIClient();
   if (!openai) return existingNarrative;
   
   try {

--- a/src/ai/smartEvidenceCollector.ts
+++ b/src/ai/smartEvidenceCollector.ts
@@ -2,21 +2,7 @@ import Stripe from 'stripe';
 import { z } from 'zod';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
-
-// Initialize Stripe client lazily
-let stripe: Stripe | null = null;
-function getStripeClient(): Stripe {
-  if (!stripe) {
-    const key = process.env.STRIPE_SECRET || process.env.STRIPE_SECRET_KEY || '';
-    if (!key || key.includes('placeholder')) {
-      throw new Error('Valid Stripe secret key required. Set STRIPE_SECRET environment variable.');
-    }
-    stripe = new Stripe(key, { 
-      apiVersion: '2024-06-20' as Stripe.LatestApiVersion 
-    });
-  }
-  return stripe;
-}
+import { getStripeClient } from '../shared/stripeClient';
 
 // Initialize DynamoDB client
 const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' });
@@ -107,7 +93,8 @@ export async function buildBundle(params: {
   
   try {
     // Fetch dispute with expanded charge
-    const dispute = await getStripeClient().disputes.retrieve(disputeId, {
+    const stripe = await getStripeClient();
+    const dispute = await stripe.disputes.retrieve(disputeId, {
       expand: ['charge', 'charge.customer', 'charge.balance_transaction']
     });
     
@@ -177,7 +164,8 @@ async function extractCustomerInfo(charge: Stripe.Charge): Promise<EvidenceBundl
     
     // If customer ID exists, fetch full customer object
     if (charge.customer && typeof charge.customer === 'string') {
-      const customer = await getStripeClient().customers.retrieve(charge.customer);
+      const stripe = await getStripeClient();
+      const customer = await stripe.customers.retrieve(charge.customer);
       if (!customer.deleted) {
         customerData = customer;
       }
@@ -223,8 +211,9 @@ async function findCE3Candidates(
   lookbackDays: number
 ): Promise<EvidenceBundle['ceCandidates']> {
   const candidates: EvidenceBundle['ceCandidates'] = [];
-  
+
   try {
+    const stripe = await getStripeClient();
     // Calculate lookback timestamp
     const lookbackTimestamp = charge.created - (lookbackDays * 86400);
     const minTimestamp = charge.created - (365 * 86400); // Max 365 days
@@ -232,7 +221,7 @@ async function findCE3Candidates(
     
     // Search by customer ID if available
     if (customer?.id) {
-      const charges = await getStripeClient().charges.list({
+      const charges = await stripe.charges.list({
         customer: customer.id,
         limit: maxTransactions * 2, // Fetch extra to filter
         created: {
@@ -261,7 +250,7 @@ async function findCE3Candidates(
     
     // Search by email if no customer ID
     if (candidates.length === 0 && customer?.email) {
-      const charges = await getStripeClient().charges.search({
+      const charges = await stripe.charges.search({
         query: `metadata["email"]:"${customer.email}" OR billing_details.email:"${customer.email}"`,
         limit: maxTransactions
       });

--- a/src/handlers/authLoginHandler.ts
+++ b/src/handlers/authLoginHandler.ts
@@ -1,8 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
+import { getOptionalSecretValue } from '../shared/secretsManager';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'stripedshield-demo-secret-2025';
 const JWT_EXPIRY = '7d'; // 7 days validity
 
 interface LoginRequest {
@@ -43,6 +43,8 @@ const DEMO_USERS = [
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
+
+  const jwtSecret = (await getOptionalSecretValue('JWT_SECRET')) || 'stripedshield-demo-secret-2025';
   
   // CORS headers
   const headers = {
@@ -108,7 +110,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           name: demoUser.name,
           iat: Math.floor(Date.now() / 1000)
         },
-        JWT_SECRET,
+        jwtSecret,
         {
           expiresIn: JWT_EXPIRY
         }
@@ -158,7 +160,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           name: demoUser.name,
           iat: Math.floor(Date.now() / 1000)
         },
-        JWT_SECRET,
+        jwtSecret,
         {
           expiresIn: JWT_EXPIRY
         }

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,6 +1,6 @@
 import { putMerchant } from "../shared/db.js";
-import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { getStripeClient, getStripeSecret } from '../shared/stripeClient';
 
 export async function handler(event:any){
   const qs = event.queryStringParameters || {};
@@ -9,8 +9,9 @@ export async function handler(event:any){
   
   if(!code) return { statusCode:400, body:'missing code' };
 
+  const stripeSecret = await getStripeSecret();
   const body = new URLSearchParams({
-    client_secret: process.env.STRIPE_SECRET!,
+    client_secret: stripeSecret,
     client_id: process.env.STRIPE_CLIENT_ID!,
     code, grant_type: 'authorization_code'
   });
@@ -73,7 +74,7 @@ export async function handler(event:any){
 
   // Register webhook endpoint for this connected account
   try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+    const stripe = await getStripeClient();
     const webhookEndpoint = await stripe.webhookEndpoints.create({
       url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
       enabled_events: [

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,7 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { getStripeSecret } from '../shared/stripeClient';
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -16,9 +17,11 @@ export async function handler(event: any) {
       TableName: MERCHANTS_TABLE,
       FilterExpression: 'attribute_exists(access_token) AND attribute_exists(refresh_token)'
     }));
-    
+
     const merchants = scanResult.Items || [];
     console.log(`Found ${merchants.length} merchants with OAuth tokens`);
+
+    const stripeSecret = await getStripeSecret();
     
     const results = {
       checked: merchants.length,
@@ -46,7 +49,7 @@ export async function handler(event: any) {
           const body = new URLSearchParams({
             grant_type: 'refresh_token',
             refresh_token: merchant.refresh_token,
-            client_secret: process.env.STRIPE_SECRET!
+            client_secret: stripeSecret
           });
           
           const response = await fetch('https://connect.stripe.com/oauth/token', {

--- a/src/handlers/buildEvidence.ts
+++ b/src/handlers/buildEvidence.ts
@@ -1,6 +1,6 @@
 import { EvidenceBundler } from '../ce3-engine/evidenceBundler';
-import { 
-  collectEvidence, 
+import {
+  collectEvidence,
   generateNarrative,
   isAIEnabled,
   type EvidenceBundle
@@ -8,6 +8,7 @@ import {
 import { CloudWatch, StandardUnit } from '@aws-sdk/client-cloudwatch';
 import { ddb } from "../shared/ddb";
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { getStripeSecret } from '../shared/stripeClient';
 
 // ML Enhancement Imports (Safe - with fallbacks)
 let patternCache: any = null;
@@ -65,7 +66,7 @@ export async function handler(evt:any){
   const { dispute, charge, payment_intent, merchant } = evt;
   
   // Use merchant's OAuth token for connected accounts, fallback to global secret
-  const stripeKey = merchant?.access_token || process.env.STRIPE_SECRET || '';
+  const stripeKey = merchant?.access_token || await getStripeSecret();
   if (!stripeKey) {
     console.error('No Stripe key available for merchant:', merchant?.id);
     throw new Error('Missing Stripe authentication for merchant');
@@ -204,7 +205,7 @@ export async function handler(evt:any){
     // Apply ML optimizations if available
     if (mlOptimizedEvidence && fraudDetected) {
       console.log('🚨 ML: Fraud detected, adding extra verification evidence');
-      evidencePackage.fraudWarning = true;
+        (evidencePackage as any).fraudWarning = true;
     }
     
     // Extract the evidence object for Stripe submission

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -1,8 +1,6 @@
-import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+import { getStripeClient } from '../shared/stripeClient';
 
 export async function handler(event: any) {
   // Get auth context if user is logged in (optional for checkout)
@@ -25,6 +23,7 @@ export async function handler(event: any) {
   }
   
   try {
+    const stripe = await getStripeClient();
     // Create or retrieve customer
     const customers = await stripe.customers.list({
       email: email,

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -2,9 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { requireAuth, verifyMerchantOwnership } from '../shared/auth.js';
 import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
-import Stripe from 'stripe';
-
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+import { getStripeClient } from '../shared/stripeClient';
 
 interface Dispute {
   id: string;
@@ -91,6 +89,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
     
     // Get REAL disputes from Stripe
+    const stripe = await getStripeClient();
     const stripeDisputes = await stripe.disputes.list(
       { limit: 100 },
       { stripeAccount: merchantId }

--- a/src/handlers/getCharge.ts
+++ b/src/handlers/getCharge.ts
@@ -1,5 +1,4 @@
-import Stripe from 'stripe';
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+import { getStripeClient } from '../shared/stripeClient';
 
 export async function handler(evt:any){
   // Safely extract stripe_account_id with proper error handling
@@ -17,8 +16,9 @@ export async function handler(evt:any){
   const chargeId = (dispute.charge as string);
   
   try {
+    const stripe = await getStripeClient();
     // Retrieve charge with optional connected account
-    const ch = stripe_account_id 
+    const ch = stripe_account_id
       ? await stripe.charges.retrieve(chargeId, { stripeAccount: stripe_account_id })
       : await stripe.charges.retrieve(chargeId);
       

--- a/src/handlers/getDispute.ts
+++ b/src/handlers/getDispute.ts
@@ -1,11 +1,10 @@
-import Stripe from 'stripe';
 import { getMerchantByAccount, upsertCase } from "../shared/db.js";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+import { getStripeClient } from '../shared/stripeClient';
 
 export async function handler(evt:any){
   const { dispute_id, merchant: { stripe_account_id } } = evt;
   const merchant = await getMerchantByAccount(stripe_account_id);
+  const stripe = await getStripeClient();
   const d = await stripe.disputes.retrieve(dispute_id, { stripeAccount: stripe_account_id });
   const tMinus = d.evidence_details?.due_by ? new Date((d.evidence_details.due_by*1000) - (48*3600*1000)).toISOString() : null;
   await upsertCase(stripe_account_id, d, {});

--- a/src/handlers/getPaymentIntent.ts
+++ b/src/handlers/getPaymentIntent.ts
@@ -1,9 +1,9 @@
-import Stripe from 'stripe';
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+import { getStripeClient } from '../shared/stripeClient';
 
 export async function handler(evt:any){
   const { charge, merchant:{stripe_account_id} } = evt;
   if(!charge?.payment_intent) return { ...evt, payment_intent: null };
+  const stripe = await getStripeClient();
   const pi = await stripe.paymentIntents.retrieve(charge.payment_intent as string, { stripeAccount: stripe_account_id });
   return { ...evt, payment_intent: pi };
 }

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -1,7 +1,7 @@
-import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { getStripeSecret } from '../shared/stripeClient';
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -27,10 +27,11 @@ export async function handler(event: any) {
     }
     
     // Refresh the token
+    const stripeSecret = await getStripeSecret();
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: merchant.refresh_token,
-      client_secret: process.env.STRIPE_SECRET!
+      client_secret: stripeSecret
     });
     
     const response = await fetch('https://connect.stripe.com/oauth/token', {

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -2,10 +2,9 @@ import { ok, bad, createErrorResponse } from "../shared/responses.js";
 import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
-import Stripe from 'stripe';
+import { getStripeClient } from '../shared/stripeClient';
 
 const sfn = new SFNClient({});
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
   // REQUIRE AUTHENTICATION
@@ -58,6 +57,7 @@ export async function handler(event: any) {
       stripeOptions = { stripeAccount: merchantId };
     }
     
+    const stripe = await getStripeClient();
     const dispute = await stripe.disputes.retrieve(disputeId, stripeOptions);
     
     // Check if evidence deadline has passed

--- a/src/handlers/stripeStageEvidence.ts
+++ b/src/handlers/stripeStageEvidence.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { getStripeClient } from '../shared/stripeClient';
 
 export async function handler(evt:any){
   const { dispute, evidence, merchant } = evt;
@@ -10,13 +11,12 @@ export async function handler(evt:any){
   if (merchant?.access_token) {
     // OAuth connected account - use access token directly
     stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil' });
-  } else if (merchant?.stripe_account_id) {
-    // Standard connected account - use global secret with stripeAccount header
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
-    stripeOptions = { stripeAccount: merchant.stripe_account_id };
   } else {
-    // Direct account - use global secret
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = await getStripeClient();
+    if (merchant?.stripe_account_id) {
+      // Standard connected account - use global secret with stripeAccount header
+      stripeOptions = { stripeAccount: merchant.stripe_account_id };
+    }
   }
   
   const res = await stripe.disputes.update(dispute.id, { evidence, submit: false }, stripeOptions);

--- a/src/handlers/stripeSubmitEvidence.ts
+++ b/src/handlers/stripeSubmitEvidence.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { getStripeClient } from '../shared/stripeClient';
 
 export async function handler(evt:any){
   const { dispute, merchant } = evt;
@@ -10,13 +11,12 @@ export async function handler(evt:any){
   if (merchant?.access_token) {
     // OAuth connected account - use access token directly
     stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil' });
-  } else if (merchant?.stripe_account_id) {
-    // Standard connected account - use global secret with stripeAccount header
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
-    stripeOptions = { stripeAccount: merchant.stripe_account_id };
   } else {
-    // Direct account - use global secret
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = await getStripeClient();
+    if (merchant?.stripe_account_id) {
+      // Standard connected account - use global secret with stripeAccount header
+      stripeOptions = { stripeAccount: merchant.stripe_account_id };
+    }
   }
   
   const res = await stripe.disputes.update(dispute.id, { submit: true }, stripeOptions);

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -2,6 +2,8 @@ import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import Stripe from 'stripe';
+import { getStripeClient } from '../shared/stripeClient';
+import { getOptionalSecretValue } from '../shared/secretsManager';
 import { 
   predictWinRate, 
   shouldSubmit,
@@ -21,7 +23,6 @@ import {
 import { CE3Detector } from "../ce3-engine/ce3Detector.js";
 import { TimingOptimizer } from "../ai-features/timingOptimizer.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
 const cloudwatch = new CloudWatch({});
 
 // Helper to publish metrics
@@ -76,7 +77,8 @@ export async function handler(event:any){
 
   try {
     // Get dispute details with charge expanded
-    const dispute = await stripe.disputes.retrieve(id, 
+    const stripe = await getStripeClient();
+    const dispute = await stripe.disputes.retrieve(id,
       { expand: ['charge'] },
       { stripeAccount: merchantId }
     );
@@ -174,11 +176,12 @@ export async function handler(event:any){
     let timingRecommendation = null;
     let shouldDelay = false;
     
-    if (process.env.OPENAI_API_KEY && !forceSubmit) {
+    const openAiKey = await getOptionalSecretValue('OPENAI_API_KEY');
+    if (openAiKey && !forceSubmit) {
       try {
         // Initialize timing optimizer with REAL implementation
         const timingOptimizer = new TimingOptimizer({
-          openaiApiKey: process.env.OPENAI_API_KEY,
+          openaiApiKey: openAiKey,
           model: 'gpt-5', // Using GPT-5 exclusive access
           temperature: Number(process.env.AI_TEMPERATURE || '0.7'),
           maxTokens: Number(process.env.AI_MAX_TOKENS || '500')

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -2,9 +2,7 @@ import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
-import Stripe from 'stripe';
-
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+import { getStripeClient } from '../shared/stripeClient';
 
 // Handle subscription lifecycle events
 export async function handleSubscriptionEvent(event: any, subscriptionEvent: any) {
@@ -244,6 +242,7 @@ export async function getSubscriptionStatus(event: any) {
     let stripeSubscription = null;
     if (merchant?.subscription_id) {
       try {
+        const stripe = await getStripeClient();
         stripeSubscription = await stripe.subscriptions.retrieve(
           merchant.subscription_id,
           { expand: ['customer', 'default_payment_method'] }
@@ -321,6 +320,7 @@ export async function cancelSubscription(event: any) {
     }
     
     // Cancel subscription at period end
+    const stripe = await getStripeClient();
     const canceledSubscription = await stripe.subscriptions.update(
       merchant.subscription_id,
       { cancel_at_period_end: true }

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -4,18 +4,19 @@ import { upsertCase } from "../shared/db.js";
 import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
-import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
-import { 
-  analyzeDispute, 
+import { getMerchantWebhookSecret, getGlobalWebhookSecret } from "../shared/webhookSecrets.js";
+import {
+  analyzeDispute,
   quickAssessRisk,
   isAIEnabled,
-  type DisputeAnalysis 
+  type DisputeAnalysis
 } from '../ai';
 import { CloudWatch, StandardUnit } from '@aws-sdk/client-cloudwatch';
 import { ddb } from "../shared/ddb.js";
 import { PutCommand, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { FeatureExtractor } from '../ml-predictor/featureExtractor';
 import { FeedbackLoop } from '../ml/feedbackLoop';
+import { getStripeClient, getStripeSecret } from '../shared/stripeClient';
 
 // ML Enhancement Imports (Safe - with fallbacks)
 let patternCache: any = null;
@@ -50,7 +51,6 @@ if (process.env.ENABLE_MODEL_UPDATER === 'true') {
   }
 }
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 const sfn = new SFNClient({});
 const cloudwatch = new CloudWatch({});
 const WEBHOOK_EVENTS_TABLE = process.env.CASES_TABLE!; // Reuse cases table for webhook events
@@ -112,17 +112,20 @@ export async function handler(event:any){
   const sig = event.headers['stripe-signature'] || event.headers['Stripe-Signature'];
   const rawBody = event.body;
   const account = (event.headers['stripe-account'] || event.headers['Stripe-Account']) as string | undefined;
-  
-  // Get the webhook secret from environment variable
+  const stripe = await getStripeClient();
+
+  // Retrieve the webhook secret from Secrets Manager
   // For production, use different secrets for account vs platform webhooks
-  const webhookSecret = account 
-    ? process.env.STRIPE_CONNECT_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test'
-    : process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test';
-  
-  if (!webhookSecret || webhookSecret === 'whsec_test') {
-    console.warn('Using test webhook secret - configure STRIPE_WEBHOOK_SECRET for production');
+  let webhookSecret: string;
+  try {
+    webhookSecret = account
+      ? await getMerchantWebhookSecret(account)
+      : await getGlobalWebhookSecret();
+  } catch (error) {
+    console.error('Failed to load Stripe webhook secret', error);
+    return { statusCode: 500, body: 'webhook secret not configured' };
   }
-  
+
   let evt: Stripe.Event;
   try{
     evt = stripe.webhooks.constructEvent(rawBody, sig!, webhookSecret);
@@ -387,7 +390,8 @@ export async function handler(event:any){
       
       try {
         // 1. Extract all features (34+ features)
-        const featureExtractor = new FeatureExtractor(process.env.STRIPE_SECRET!);
+        const stripeSecret = await getStripeSecret();
+        const featureExtractor = new FeatureExtractor(stripeSecret);
         const features = await featureExtractor.extractAllFeatures(dispute);
         
         // 2. Get our original prediction (if exists)

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,16 +1,17 @@
 import admin from 'firebase-admin';
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "./ddb.js";
+import { getOptionalSecretValue } from './secretsManager';
 
 // Initialize Firebase Admin SDK
 let firebaseApp: admin.app.App | null = null;
 
-function initFirebaseAdmin() {
+async function initFirebaseAdmin(): Promise<admin.app.App> {
   if (!firebaseApp) {
     try {
-      // Use service account from environment (loaded from SSM)
-      if (process.env.FIREBASE_SERVICE_ACCOUNT) {
-        const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+      const serviceAccountSecret = await getOptionalSecretValue('FIREBASE_SERVICE_ACCOUNT');
+      if (serviceAccountSecret) {
+        const serviceAccount = JSON.parse(serviceAccountSecret);
         firebaseApp = admin.initializeApp({
           credential: admin.credential.cert(serviceAccount),
           projectId: serviceAccount.project_id || process.env.FIREBASE_PROJECT_ID || "stripecharge-b27a6"
@@ -51,7 +52,7 @@ export async function validateAuth(authHeader: string | undefined): Promise<Auth
   const token = authHeader.substring(7);
   
   try {
-    const app = initFirebaseAdmin();
+    const app = await initFirebaseAdmin();
     const decodedToken = await admin.auth(app).verifyIdToken(token);
     
     // Get merchant info from DynamoDB if exists

--- a/src/shared/openaiClient.ts
+++ b/src/shared/openaiClient.ts
@@ -1,0 +1,37 @@
+import OpenAI from 'openai';
+import { getSecretValue, SECRET_CACHE_TTL_MS } from './secretsManager';
+
+type OpenAICacheEntry = {
+  client: OpenAI;
+  apiKey: string;
+  expiresAt: number;
+};
+
+let cachedOpenAI: OpenAICacheEntry | null = null;
+
+export async function getOpenAIClient(): Promise<OpenAI | null> {
+  try {
+    const apiKey = (await getSecretValue('OPENAI_API_KEY')).trim();
+    if (!apiKey) {
+      console.warn('[openaiClient] OPENAI_API_KEY secret is empty');
+      return null;
+    }
+
+    const now = Date.now();
+    if (cachedOpenAI && cachedOpenAI.apiKey === apiKey && cachedOpenAI.expiresAt > now) {
+      return cachedOpenAI.client;
+    }
+
+    const client = new OpenAI({ apiKey });
+    cachedOpenAI = {
+      client,
+      apiKey,
+      expiresAt: now + SECRET_CACHE_TTL_MS
+    };
+
+    return client;
+  } catch (error) {
+    console.error('[openaiClient] Failed to load OpenAI API key from Secrets Manager', error);
+    return null;
+  }
+}

--- a/src/shared/secretsManager.ts
+++ b/src/shared/secretsManager.ts
@@ -1,0 +1,110 @@
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+
+const secretsClient = new SecretsManagerClient({});
+const SECRET_CACHE_TTL_MS = 60_000;
+
+interface SecretCacheEntry {
+  value: string;
+  expiresAt: number;
+}
+
+const cache = new Map<string, SecretCacheEntry>();
+const inflightFetches = new Map<string, Promise<string>>();
+
+function resolveSecretId(secretName: string): string {
+  const override = process.env[`${secretName}_SECRET_ID`];
+  if (override) {
+    return override;
+  }
+
+  const prefix = process.env.SECRETS_MANAGER_PREFIX;
+  if (prefix) {
+    const normalizedPrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+    if (secretName.startsWith(normalizedPrefix)) {
+      return secretName;
+    }
+    return `${normalizedPrefix}/${secretName}`;
+  }
+
+  return secretName;
+}
+
+async function fetchSecret(secretId: string): Promise<string> {
+  const now = Date.now();
+  const cached = cache.get(secretId);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  const inflight = inflightFetches.get(secretId);
+  if (inflight) {
+    return inflight;
+  }
+
+  const fetchPromise = (async () => {
+    try {
+      const response = await secretsClient.send(new GetSecretValueCommand({
+        SecretId: secretId
+      }));
+
+      const secretString = response.SecretString ?? (response.SecretBinary ? Buffer.from(response.SecretBinary).toString('utf-8') : undefined);
+      if (secretString === undefined) {
+        throw new Error(`Secret ${secretId} has no retrievable value`);
+      }
+
+      cache.set(secretId, {
+        value: secretString,
+        expiresAt: Date.now() + SECRET_CACHE_TTL_MS
+      });
+
+      return secretString;
+    } finally {
+      inflightFetches.delete(secretId);
+    }
+  })();
+
+  inflightFetches.set(secretId, fetchPromise);
+  return fetchPromise;
+}
+
+export async function getSecretValue(secretName: string): Promise<string> {
+  const secretId = resolveSecretId(secretName);
+  return fetchSecret(secretId);
+}
+
+export async function getOptionalSecretValue(secretName: string): Promise<string | undefined> {
+  try {
+    const value = await getSecretValue(secretName);
+    if (!value) {
+      return undefined;
+    }
+    return value;
+  } catch (error: any) {
+    if (error?.$metadata?.httpStatusCode === 404 || error?.name === 'ResourceNotFoundException') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export async function getJsonSecret<T>(secretName: string): Promise<T> {
+  const secretValue = await getSecretValue(secretName);
+  try {
+    return JSON.parse(secretValue) as T;
+  } catch (error) {
+    throw new Error(`Secret ${secretName} is not valid JSON`);
+  }
+}
+
+export function clearSecretCache(secretName?: string): void {
+  if (secretName) {
+    const secretId = resolveSecretId(secretName);
+    cache.delete(secretId);
+    inflightFetches.delete(secretId);
+  } else {
+    cache.clear();
+    inflightFetches.clear();
+  }
+}
+
+export { SECRET_CACHE_TTL_MS };

--- a/src/shared/stripeClient.ts
+++ b/src/shared/stripeClient.ts
@@ -1,0 +1,41 @@
+import Stripe from 'stripe';
+import { getSecretValue, SECRET_CACHE_TTL_MS } from './secretsManager';
+
+const STRIPE_API_VERSION: Stripe.LatestApiVersion = '2025-07-30.basil';
+
+type StripeCacheEntry = {
+  client: Stripe;
+  secret: string;
+  expiresAt: number;
+};
+
+let cachedStripe: StripeCacheEntry | null = null;
+
+export async function getStripeClient(): Promise<Stripe> {
+  const secret = (await getSecretValue('STRIPE_SECRET')).trim();
+  if (!secret) {
+    throw new Error('Stripe secret is empty');
+  }
+
+  const now = Date.now();
+  if (cachedStripe && cachedStripe.secret === secret && cachedStripe.expiresAt > now) {
+    return cachedStripe.client;
+  }
+
+  const client = new Stripe(secret, { apiVersion: STRIPE_API_VERSION });
+  cachedStripe = {
+    client,
+    secret,
+    expiresAt: now + SECRET_CACHE_TTL_MS
+  };
+
+  return client;
+}
+
+export async function getStripeSecret(): Promise<string> {
+  const secret = (await getSecretValue('STRIPE_SECRET')).trim();
+  if (!secret) {
+    throw new Error('Stripe secret is empty');
+  }
+  return secret;
+}

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,10 +1,10 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { getSecretValue, getOptionalSecretValue } from './secretsManager';
+import { getStripeClient } from './stripeClient';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
-const ssm = new SSMClient({});
 
 const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE || 'MerchantsTable';
 
@@ -37,38 +37,30 @@ export async function getMerchantWebhookSecret(merchantId: string): Promise<stri
     console.error(`[WEBHOOK] Error fetching merchant webhook secret:`, error);
   }
   
-  // Fallback to global webhook secret from environment/SSM
+  // Fallback to Secrets Manager global secrets
+  const connectSecret = await getConnectWebhookSecret();
+  if (connectSecret) {
+    console.log('[WEBHOOK] Using global connect webhook secret from Secrets Manager');
+    return connectSecret;
+  }
+
   return getGlobalWebhookSecret();
 }
 
 /**
  * Get the global webhook secret from environment or SSM
  */
-async function getGlobalWebhookSecret(): Promise<string> {
-  // First check environment variable
-  if (process.env.STRIPE_CONNECT_WEBHOOK_SECRET) {
-    console.log('[WEBHOOK] Using global webhook secret from environment');
-    return process.env.STRIPE_CONNECT_WEBHOOK_SECRET;
+export async function getGlobalWebhookSecret(): Promise<string> {
+  const secret = (await getSecretValue('STRIPE_WEBHOOK_SECRET')).trim();
+  if (!secret) {
+    throw new Error('STRIPE_WEBHOOK_SECRET is not configured in Secrets Manager');
   }
-  
-  // Try to fetch from SSM Parameter Store
-  try {
-    const result = await ssm.send(new GetParameterCommand({
-      Name: '/stripedshield/prod/STRIPE_WEBHOOK_SECRET',
-      WithDecryption: true
-    }));
-    
-    if (result.Parameter?.Value) {
-      console.log('[WEBHOOK] Using global webhook secret from SSM');
-      return result.Parameter.Value;
-    }
-  } catch (error) {
-    console.error('[WEBHOOK] Error fetching webhook secret from SSM:', error);
-  }
-  
-  // Last resort fallback - should not happen in production
-  console.error('[WEBHOOK] WARNING: No webhook secret found, webhooks will fail validation!');
-  throw new Error('No webhook secret configured');
+  return secret;
+}
+
+async function getConnectWebhookSecret(): Promise<string | undefined> {
+  const secret = await getOptionalSecretValue('STRIPE_CONNECT_WEBHOOK_SECRET');
+  return secret?.trim() || undefined;
 }
 
 /**
@@ -82,15 +74,14 @@ export async function validateWebhookSignature(
   signature: string,
   accountId?: string
 ): Promise<boolean> {
-  const Stripe = require('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+  const stripe = await getStripeClient();
   
   try {
     // Get the appropriate webhook secret
-    const webhookSecret = accountId 
+    const webhookSecret = accountId
       ? await getMerchantWebhookSecret(accountId)
       : await getGlobalWebhookSecret();
-    
+
     // Verify the webhook signature
     const event = stripe.webhooks.constructEvent(
       payload,


### PR DESCRIPTION
## Summary
- add a Secrets Manager utility with 60s in-memory caching plus helpers for Stripe and OpenAI clients
- update handlers, AI modules, and auth flows to pull required secrets from Secrets Manager instead of environment variables
- adjust serverless configuration to stop injecting secret values and grant access to Secrets Manager APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68defb780800832fb510031befb09836