### PR TITLE
Implement atomic DynamoDB rate limiting

### DIFF
--- a/src/shared/rateLimit.ts
+++ b/src/shared/rateLimit.ts
@@ -1,6 +1,7 @@
 import { createErrorResponse } from './responses.js';
 import { ddb } from './ddb.js';
-import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 
 const RATE_LIMIT_TABLE = process.env.CASES_TABLE!; // Reuse cases table
 
@@ -10,50 +11,67 @@ interface RateLimitConfig {
   identifier: string;
 }
 
+interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+}
+
+const TTL_BUFFER_SECONDS = 60; // keep window records slightly longer than the window itself
+
 /**
  * Simple rate limiting middleware using DynamoDB
  * @param config Rate limit configuration
  * @returns true if request should be allowed, false if rate limited
  */
-export async function checkRateLimit(config: RateLimitConfig): Promise<boolean> {
+export async function checkRateLimit(config: RateLimitConfig): Promise<RateLimitResult> {
   const now = Math.floor(Date.now() / 1000);
-  const windowStart = now - config.windowSeconds;
-  
+  const windowStart = Math.floor(now / config.windowSeconds) * config.windowSeconds;
+  const windowEnd = windowStart + config.windowSeconds;
+
   // Create a unique key for this rate limit window
   const pk = `RATELIMIT#${config.identifier}`;
   const sk = `WINDOW#${windowStart}`;
-  
+
   try {
-    // Get current window data
-    const result = await ddb.send(new GetCommand({
+    const updateResult = await ddb.send(new UpdateCommand({
       TableName: RATE_LIMIT_TABLE,
-      Key: { pk, sk }
+      Key: { pk, sk },
+      UpdateExpression: 'ADD #count :incr SET #ttl = :ttl, #windowStart = :windowStart, #updatedAt = :now',
+      ExpressionAttributeNames: {
+        '#count': 'count',
+        '#ttl': 'ttl',
+        '#windowStart': 'windowStart',
+        '#updatedAt': 'updatedAt'
+      },
+      ExpressionAttributeValues: {
+        ':incr': 1,
+        ':ttl': windowEnd + TTL_BUFFER_SECONDS,
+        ':windowStart': windowStart,
+        ':now': now,
+        ':max': config.maxRequests
+      },
+      ConditionExpression: 'attribute_not_exists(#count) OR #count < :max',
+      ReturnValues: 'UPDATED_NEW'
     }));
-    
-    const currentCount = result.Item?.count || 0;
-    
-    // Check if rate limit exceeded
-    if (currentCount >= config.maxRequests) {
-      console.log(`Rate limit exceeded for ${config.identifier}: ${currentCount}/${config.maxRequests}`);
-      return false;
+
+    const currentCount = (updateResult.Attributes?.count as number | undefined) ?? 0;
+    if (currentCount > 0) {
+      const remaining = Math.max(0, config.maxRequests - currentCount);
+      console.debug(`Rate limit usage for ${config.identifier}: ${currentCount}/${config.maxRequests} (remaining ${remaining})`);
     }
-    
-    // Increment counter
-    await ddb.send(new PutCommand({
-      TableName: RATE_LIMIT_TABLE,
-      Item: {
-        pk,
-        sk,
-        count: currentCount + 1,
-        ttl: now + config.windowSeconds + 3600 // TTL: window + 1 hour
-      }
-    }));
-    
-    return true;
+
+    return { allowed: true };
   } catch (error) {
+    const err = error as { name?: string };
+    if (error instanceof ConditionalCheckFailedException || err?.name === 'ConditionalCheckFailedException') {
+      const retryAfter = Math.max(1, windowEnd - now);
+      console.warn(`Rate limit exceeded for ${config.identifier}: max ${config.maxRequests} requests in ${config.windowSeconds}s window`);
+      return { allowed: false, retryAfterSeconds: retryAfter };
+    }
+
     console.error('Rate limit check error:', error);
     // Allow request on error to avoid blocking legitimate traffic
-    return true;
+    return { allowed: true };
   }
 }
 
@@ -96,16 +114,19 @@ export function getRateLimitConfig(path: string, sourceIp: string): RateLimitCon
 export async function rateLimitMiddleware(event: any): Promise<any> {
   const sourceIp = event.requestContext?.identity?.sourceIp || 'unknown';
   const path = event.path || '/';
-  
+
   const config = getRateLimitConfig(path, sourceIp);
-  const allowed = await checkRateLimit(config);
-  
-  if (!allowed) {
+  const result = await checkRateLimit(config);
+
+  if (!result.allowed) {
+    const retryAfterSeconds = result.retryAfterSeconds ?? config.windowSeconds;
     return createErrorResponse(429, 'Too Many Requests', {
       message: 'Rate limit exceeded. Please try again later.',
-      retryAfter: config.windowSeconds
+      retryAfter: retryAfterSeconds
+    }, {
+      'Retry-After': retryAfterSeconds.toString()
     });
   }
-  
+
   return null; // Continue processing
 }

--- a/src/shared/responses.ts
+++ b/src/shared/responses.ts
@@ -33,11 +33,16 @@ export const bad = (msg:string) => ({
   body: JSON.stringify({ error: msg })
 });
 
-export const createErrorResponse = (statusCode: number, message: string, details?: any) => ({
+export const createErrorResponse = (
+  statusCode: number,
+  message: string,
+  details?: any,
+  extraHeaders?: Record<string, string>
+) => ({
   statusCode,
-  headers: securityHeaders,
-  body: JSON.stringify({ 
+  headers: { ...securityHeaders, ...(extraHeaders ?? {}) },
+  body: JSON.stringify({
     error: message,
-    ...details 
+    ...details
   })
 });


### PR DESCRIPTION
## Summary
- replace the non-atomic rate limiter with a fixed-window DynamoDB counter update that uses conditional updates and TTLs
- return structured results from the limiter so 429 responses include an accurate Retry-After header while preserving existing security headers
- extend the shared error response helper to support custom headers for rate-limit responses

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68defa632820832f8758667df4647e41