### PR TITLE
Refine merchant updates to use DynamoDB UpdateCommand

### DIFF
--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,4 +1,4 @@
-import { putMerchant } from "../shared/db.js";
+import { updateMerchantTokens, updateMerchantWebhook } from "../shared/db.js";
 import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
 
@@ -42,9 +42,7 @@ export async function handler(event:any){
   }
 
   // Save all OAuth data to DynamoDB
-  await putMerchant({ 
-    merchant_id,
-    stripe_account_id: merchant_id,
+  await updateMerchantTokens(merchant_id, {
     access_token, // CRITICAL: Save this for API calls
     refresh_token, // CRITICAL: Save this for token refresh
     token_type,
@@ -89,8 +87,7 @@ export async function handler(event:any){
     console.log('Webhook endpoint registered:', webhookEndpoint.id);
     
     // Save webhook endpoint ID
-    await putMerchant({
-      merchant_id,
+    await updateMerchantWebhook(merchant_id, {
       webhook_endpoint_id: webhookEndpoint.id,
       webhook_secret: webhookEndpoint.secret
     });

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,6 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
-import { putMerchant } from "../shared/db.js";
+import { updateMerchantTokens } from "../shared/db.js";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -59,8 +59,7 @@ export async function handler(event: any) {
           
           if (json.access_token) {
             // Save new tokens
-            await putMerchant({
-              merchant_id: merchant.merchant_id,
+            await updateMerchantTokens(merchant.merchant_id, {
               access_token: json.access_token,
               refresh_token: json.refresh_token || merchant.refresh_token,
               token_refreshed_at: new Date().toISOString()

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -1,7 +1,7 @@
 import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
-import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { getMerchantByAccount, updateMerchantTokens } from "../shared/db.js";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -47,8 +47,7 @@ export async function handler(event: any) {
     }
     
     // Save new tokens
-    await putMerchant({
-      merchant_id: authContext.merchant_id,
+    await updateMerchantTokens(authContext.merchant_id, {
       access_token: json.access_token,
       refresh_token: json.refresh_token || merchant.refresh_token, // Use new refresh token if provided
       token_refreshed_at: new Date().toISOString()

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -1,7 +1,7 @@
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
-import { putMerchant, getCase } from "../shared/db.js";
+import { updateMerchantAttributes, getCase } from "../shared/db.js";
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
@@ -76,8 +76,7 @@ async function handleSubscriptionCreated(merchantId: string, subscription: any) 
   console.log(`[SUBSCRIPTION] Created for merchant ${merchantId}: ${subscription.id}`);
   
   // Update merchant with subscription info
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     subscription_id: subscription.id,
     subscription_status: subscription.status,
     subscription_current_period_end: subscription.current_period_end,
@@ -97,8 +96,7 @@ async function handleSubscriptionUpdated(merchantId: string, subscription: any) 
   console.log(`[SUBSCRIPTION] Updated for merchant ${merchantId}: ${subscription.id}`);
   
   // Update subscription status
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     subscription_status: subscription.status,
     subscription_current_period_end: subscription.current_period_end,
     subscription_cancel_at_period_end: subscription.cancel_at_period_end,
@@ -119,8 +117,7 @@ async function handleSubscriptionDeleted(merchantId: string, subscription: any) 
   console.log(`[SUBSCRIPTION] Deleted for merchant ${merchantId}: ${subscription.id}`);
   
   // Mark subscription as canceled
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     subscription_status: 'canceled',
     subscription_canceled_at: new Date().toISOString(),
     premium_features_active: false
@@ -135,8 +132,7 @@ async function handleTrialWillEnd(merchantId: string, subscription: any) {
   
   // Send notification about trial ending (implement email/notification service)
   // For now, just log it
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     trial_ending_notification_sent: new Date().toISOString()
   });
 }
@@ -144,8 +140,7 @@ async function handleTrialWillEnd(merchantId: string, subscription: any) {
 async function handleSubscriptionPaused(merchantId: string, subscription: any) {
   console.log(`[SUBSCRIPTION] Paused for merchant ${merchantId}: ${subscription.id}`);
   
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     subscription_status: 'paused',
     subscription_paused_at: new Date().toISOString(),
     premium_features_active: false
@@ -158,8 +153,7 @@ async function handleSubscriptionPaused(merchantId: string, subscription: any) {
 async function handleSubscriptionResumed(merchantId: string, subscription: any) {
   console.log(`[SUBSCRIPTION] Resumed for merchant ${merchantId}: ${subscription.id}`);
   
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     subscription_status: 'active',
     subscription_resumed_at: new Date().toISOString(),
     premium_features_active: true
@@ -173,8 +167,7 @@ async function handlePastDueSubscription(merchantId: string) {
   console.log(`[SUBSCRIPTION] Handling past due for merchant ${merchantId}`);
   
   // Limit features for past due accounts
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     premium_features_limited: true,
     past_due_notification_sent: new Date().toISOString()
   });
@@ -183,8 +176,7 @@ async function handlePastDueSubscription(merchantId: string) {
 async function activatePremiumFeatures(merchantId: string) {
   console.log(`[FEATURES] Activating premium features for merchant ${merchantId}`);
   
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     premium_features_active: true,
     ai_enabled: true,
     ce3_detection_enabled: true,
@@ -199,8 +191,7 @@ async function activatePremiumFeatures(merchantId: string) {
 async function deactivatePremiumFeatures(merchantId: string) {
   console.log(`[FEATURES] Deactivating premium features for merchant ${merchantId}`);
   
-  await putMerchant({
-    merchant_id: merchantId,
+  await updateMerchantAttributes(merchantId, {
     premium_features_active: false,
     ai_enabled: false,
     ce3_detection_enabled: false,
@@ -327,8 +318,7 @@ export async function cancelSubscription(event: any) {
     );
     
     // Update merchant record
-    await putMerchant({
-      merchant_id: merchantId,
+    await updateMerchantAttributes(merchantId, {
       subscription_cancel_at_period_end: true,
       subscription_cancel_requested_at: new Date().toISOString()
     });

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,20 +1,132 @@
 import { ddb } from "./ddb.js";
-import { PutCommand, GetCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { PutCommand, GetCommand, QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 
 const MERCHANTS = process.env.MERCHANTS_TABLE!;
 const CASES = process.env.CASES_TABLE!;
 
-export async function putMerchant(m:any){
-  // Use stripe_account_id as the primary key for consistency
-  const merchant_id = m.stripe_account_id || m.merchant_id;
-  const item = {
-    pk: `MERCHANT#${merchant_id}`,
-    merchant_id: merchant_id,
-    stripe_account_id: merchant_id, // Ensure both fields are set
-    ...m,
-    created_at: m.created_at || new Date().toISOString()
+type MerchantUpdateMap = Record<string, unknown>;
+
+function buildMerchantUpdateCommand(merchantId: string, updates: MerchantUpdateMap) {
+  const pk = `MERCHANT#${merchantId}`;
+  const timestamp = new Date().toISOString();
+
+  const expressionAttributeNames: Record<string, string> = {
+    "#merchant_id": "merchant_id",
+    "#stripe_account_id": "stripe_account_id",
+    "#updated_at": "updated_at",
+    "#created_at": "created_at"
   };
-  await ddb.send(new PutCommand({ TableName: MERCHANTS, Item: item }));
+
+  const expressionAttributeValues: Record<string, unknown> = {
+    ":merchant_id": merchantId,
+    ":stripe_account_id": merchantId,
+    ":updated_at": timestamp,
+    ":created_at": timestamp
+  };
+
+  const setExpressions = [
+    "#updated_at = :updated_at",
+    "#merchant_id = if_not_exists(#merchant_id, :merchant_id)",
+    "#stripe_account_id = if_not_exists(#stripe_account_id, :stripe_account_id)",
+    "#created_at = if_not_exists(#created_at, :created_at)"
+  ];
+
+  let index = 0;
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    const attributeName = `#attr${index}`;
+    const attributeValue = `:val${index}`;
+    expressionAttributeNames[attributeName] = key;
+    expressionAttributeValues[attributeValue] = value;
+    setExpressions.push(`${attributeName} = ${attributeValue}`);
+    index++;
+  }
+
+  return {
+    Key: { pk },
+    TableName: MERCHANTS,
+    UpdateExpression: `SET ${setExpressions.join(", ")}`,
+    ExpressionAttributeNames: expressionAttributeNames,
+    ExpressionAttributeValues: expressionAttributeValues
+  };
+}
+
+export async function updateMerchantAttributes(merchantId: string, updates: MerchantUpdateMap) {
+  const commandInput = buildMerchantUpdateCommand(merchantId, updates);
+  await ddb.send(new UpdateCommand(commandInput));
+}
+
+type MerchantTokenUpdates = {
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  stripe_publishable_key?: string;
+  scope?: string;
+  livemode?: boolean;
+  firebase_uid?: string | null;
+  oauth_connected_at?: string;
+  token_refreshed_at?: string;
+};
+
+export async function updateMerchantTokens(merchantId: string, updates: MerchantTokenUpdates) {
+  const filteredUpdates: MerchantUpdateMap = {};
+  const allowedKeys: (keyof MerchantTokenUpdates)[] = [
+    "access_token",
+    "refresh_token",
+    "token_type",
+    "stripe_publishable_key",
+    "scope",
+    "livemode",
+    "firebase_uid",
+    "oauth_connected_at",
+    "token_refreshed_at"
+  ];
+
+  for (const key of allowedKeys) {
+    const value = updates[key];
+    if (value !== undefined) {
+      filteredUpdates[key] = value;
+    }
+  }
+
+  if (Object.keys(filteredUpdates).length === 0) {
+    return;
+  }
+
+  const hasRefreshTimestamp = Object.prototype.hasOwnProperty.call(filteredUpdates, "token_refreshed_at");
+  const hasTokenChange = updates.access_token !== undefined || updates.refresh_token !== undefined;
+
+  if (!hasRefreshTimestamp && (updates.token_refreshed_at !== undefined || hasTokenChange)) {
+    filteredUpdates["token_refreshed_at"] = updates.token_refreshed_at ?? new Date().toISOString();
+  }
+
+  await updateMerchantAttributes(merchantId, filteredUpdates);
+}
+
+type MerchantWebhookUpdates = {
+  webhook_endpoint_id?: string | null;
+  webhook_secret?: string | null;
+  webhook_status?: string;
+};
+
+export async function updateMerchantWebhook(merchantId: string, updates: MerchantWebhookUpdates) {
+  const filteredUpdates: MerchantUpdateMap = {};
+  const allowedKeys: (keyof MerchantWebhookUpdates)[] = [
+    "webhook_endpoint_id",
+    "webhook_secret",
+    "webhook_status"
+  ];
+
+  for (const key of allowedKeys) {
+    const value = updates[key];
+    if (value !== undefined) {
+      filteredUpdates[key] = value;
+    }
+  }
+
+  filteredUpdates.webhook_updated_at = new Date().toISOString();
+
+  await updateMerchantAttributes(merchantId, filteredUpdates);
 }
 
 export async function getMerchantByAccount(stripe_account_id:string){


### PR DESCRIPTION
## Summary
- replace merchant PutCommand writes with targeted UpdateCommand helpers to prevent record overwrites
- add updateMerchantTokens and updateMerchantWebhook utilities and reuse them across token, webhook, and subscription flows
- update handlers to call the new helpers so only specific merchant fields are modified

## Testing
- npm test *(fails: Jest exits with module naming collisions and no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68defa2d8e9c832fb014839a9de289b2