### PR TITLE
Use account-specific webhook secrets from DynamoDB

### DIFF
--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -4,7 +4,7 @@ import { upsertCase } from "../shared/db.js";
 import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
-import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { validateWebhookSignature } from "../shared/webhookSecrets.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -110,25 +110,26 @@ async function markEventProcessed(eventId: string, eventType: string): Promise<v
 
 export async function handler(event:any){
   const sig = event.headers['stripe-signature'] || event.headers['Stripe-Signature'];
-  const rawBody = event.body;
   const account = (event.headers['stripe-account'] || event.headers['Stripe-Account']) as string | undefined;
-  
-  // Get the webhook secret from environment variable
-  // For production, use different secrets for account vs platform webhooks
-  const webhookSecret = account 
-    ? process.env.STRIPE_CONNECT_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test'
-    : process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test';
-  
-  if (!webhookSecret || webhookSecret === 'whsec_test') {
-    console.warn('Using test webhook secret - configure STRIPE_WEBHOOK_SECRET for production');
+  const rawBody = event.isBase64Encoded ? Buffer.from(event.body, 'base64') : event.body;
+
+  if (!rawBody) {
+    console.error('Missing webhook payload');
+    return { statusCode: 400, body: 'missing payload' };
   }
-  
+
+  if (!sig) {
+    console.error('Missing Stripe-Signature header');
+    return { statusCode: 400, body: 'missing signature' };
+  }
+
   let evt: Stripe.Event;
-  try{
-    evt = stripe.webhooks.constructEvent(rawBody, sig!, webhookSecret);
-  }catch(e:any){
-    console.error(`Webhook signature verification failed for account ${account}:`, e.message);
-    return { statusCode:400, body:`bad sig: ${e.message}` };
+  try {
+    evt = await validateWebhookSignature(rawBody, sig, account);
+  } catch (e: any) {
+    const message = e?.message || 'unknown error';
+    console.error(`Webhook signature verification failed for account ${account || 'platform'}:`, e);
+    return { statusCode: 400, body: `bad sig: ${message}` };
   }
 
   // Check idempotency - prevent duplicate processing

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import Stripe from 'stripe';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
@@ -44,7 +45,7 @@ export async function getMerchantWebhookSecret(merchantId: string): Promise<stri
 /**
  * Get the global webhook secret from environment or SSM
  */
-async function getGlobalWebhookSecret(): Promise<string> {
+export async function getGlobalWebhookSecret(): Promise<string> {
   // First check environment variable
   if (process.env.STRIPE_CONNECT_WEBHOOK_SECRET) {
     console.log('[WEBHOOK] Using global webhook secret from environment');
@@ -77,32 +78,35 @@ async function getGlobalWebhookSecret(): Promise<string> {
  * @param signature The Stripe-Signature header
  * @param accountId Optional Stripe account ID for Connect webhooks
  */
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+
 export async function validateWebhookSignature(
   payload: string | Buffer,
   signature: string,
   accountId?: string
-): Promise<boolean> {
-  const Stripe = require('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
-  
+): Promise<Stripe.Event> {
+  if (!signature) {
+    throw new Error('Missing Stripe-Signature header');
+  }
+
+  // Get the appropriate webhook secret
+  const webhookSecret = accountId
+    ? await getMerchantWebhookSecret(accountId)
+    : await getGlobalWebhookSecret();
+
   try {
-    // Get the appropriate webhook secret
-    const webhookSecret = accountId 
-      ? await getMerchantWebhookSecret(accountId)
-      : await getGlobalWebhookSecret();
-    
-    // Verify the webhook signature
-    const event = stripe.webhooks.constructEvent(
-      payload,
-      signature,
-      webhookSecret
+    // Verify the webhook signature and return the event for downstream processing
+    const event = stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+    console.log(
+      `[WEBHOOK] Signature validated for event ${event.id} (${accountId ?? 'platform'})`
     );
-    
-    console.log(`[WEBHOOK] Signature validated for event ${event.id}`);
-    return true;
+    return event;
   } catch (error) {
-    console.error('[WEBHOOK] Signature validation failed:', error);
-    return false;
+    console.error(
+      `[WEBHOOK] Signature validation failed${accountId ? ` for ${accountId}` : ''}:`,
+      error
+    );
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- load Stripe webhook secrets per connected account from DynamoDB instead of relying on a global environment value
- centralize signature verification in the shared helper so the handler validates and returns the event using the retrieved secret
- improve error handling in the webhook handler for missing payloads or signature headers

## Testing
- npm run build *(fails: src/handlers/buildEvidence.ts(207,23): error TS2339: Property 'fraudWarning' does not exist on type 'EvidencePackage'.)*

------
https://chatgpt.com/codex/tasks/task_e_68def9feaee0832fa64f46c71d73fd3b