### PR TITLE
Add GitHub Actions CI/CD pipeline and deployment script

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,82 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --passWithNoTests
+
+      - name: Build project
+        run: npm run build
+
+      - name: Archive build artifacts
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: |
+            dist
+            stepfunctions.yml
+            serverless.yml
+
+  deploy:
+    name: Deploy to AWS
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: production
+      url: ${{ steps.serverless.outputs.endpoint-url || '' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy with Serverless
+        id: serverless
+        env:
+          NODE_ENV: production
+        run: |
+          ./scripts/deploy.sh --stage prod
+          npx serverless info --stage prod --verbose || true
+        continue-on-error: false

--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ npm run build
 npx serverless deploy --stage prod
 ```
 
+### Automated deployment scripts
+
+You can automate the end-to-end build and deployment workflow with the provided helper script:
+
+```bash
+# From the repository root
+./scripts/deploy.sh --stage prod
+
+# Deploy to another stage without rebuilding artifacts
+./scripts/deploy.sh --stage dev --skip-build
+```
+
+The script installs dependencies (if needed), compiles the TypeScript project, and deploys the selected Serverless stage. It relies on the standard AWS credential environment variables and any application secrets required by the deployed Lambdas.
+
 ### Configuration
 
 Set environment variables in Lambda:
@@ -159,6 +173,15 @@ const response = await openai.chat.completions.create({
 - ✅ Core business logic
 - ✅ 68% win rate achieved
 - ✅ Performance targets met
+
+## 🔄 Continuous Integration & Deployment
+
+GitHub Actions automates testing and deployment for this repository:
+
+- **CI** runs on every pull request and push to `main`. It installs dependencies, executes Jest with `--passWithNoTests`, and builds the TypeScript project to ensure the Serverless handlers compile successfully.
+- **CD** runs after a successful `main` branch build. It deploys the `prod` stage through the Serverless framework using the `scripts/deploy.sh` helper. Configure the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` repository secrets to enable production deployments. Additional runtime secrets (Stripe, OpenAI, Redis, etc.) should be stored in the associated GitHub environment.
+
+Trigger the workflow manually at any time with **Run workflow** from the Actions tab to redeploy on demand.
 
 ### Completed ✅
 - ✅ Redis connectivity fixed (27ms latency)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${DEBUG:-}" == "true" ]]; then
+  set -x
+fi
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--stage <stage>] [--skip-build]
+
+Options:
+  --stage <stage>   Deployment stage to target (defaults to prod).
+  --skip-build      Skip the TypeScript build step and deploy the previously built artifacts.
+  -h, --help        Show this message.
+
+Environment variables:
+  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, and STRIPE keys must be set for deployment.
+USAGE
+}
+
+STAGE="prod"
+SKIP_BUILD="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f package.json ]]; then
+  echo "This script must be run from the repository root." >&2
+  exit 1
+fi
+
+if [[ ! -d node_modules ]]; then
+  echo "Installing npm dependencies..."
+  npm ci
+fi
+
+if [[ "$SKIP_BUILD" != "true" ]]; then
+  echo "Building project artifacts..."
+  npm run build
+else
+  echo "Skipping build step as requested."
+fi
+
+echo "Deploying stage '$STAGE' via Serverless..."
+if [[ "$STAGE" == "prod" ]]; then
+  npx serverless deploy --stage prod
+else
+  npx serverless deploy --stage "$STAGE"
+fi
+
+echo "Deployment complete."

--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {


### PR DESCRIPTION
## Summary
- add a reusable deployment helper script that installs dependencies, builds, and deploys with Serverless
- document deployment automation and the GitHub Actions pipeline in the README
- configure a CI/CD workflow that builds, tests, archives artifacts, and deploys the prod stage on main
- extend the EvidencePackage type with an optional fraud warning flag to satisfy TypeScript builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deef846dac832fb03484ca6c7753e3