### PR TITLE
Add webhook timestamp validation for Stripe signature checks

### DIFF
--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -4,7 +4,7 @@ import { upsertCase } from "../shared/db.js";
 import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
-import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { validateWebhookSignature } from "../shared/webhookSecrets.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -112,20 +112,14 @@ export async function handler(event:any){
   const sig = event.headers['stripe-signature'] || event.headers['Stripe-Signature'];
   const rawBody = event.body;
   const account = (event.headers['stripe-account'] || event.headers['Stripe-Account']) as string | undefined;
-  
-  // Get the webhook secret from environment variable
-  // For production, use different secrets for account vs platform webhooks
-  const webhookSecret = account 
-    ? process.env.STRIPE_CONNECT_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test'
-    : process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test';
-  
-  if (!webhookSecret || webhookSecret === 'whsec_test') {
-    console.warn('Using test webhook secret - configure STRIPE_WEBHOOK_SECRET for production');
-  }
-  
+
   let evt: Stripe.Event;
   try{
-    evt = stripe.webhooks.constructEvent(rawBody, sig!, webhookSecret);
+    if (!sig) {
+      throw new Error('Missing Stripe-Signature header');
+    }
+
+    evt = await validateWebhookSignature(rawBody, sig, account, { stripeClient: stripe });
   }catch(e:any){
     console.error(`Webhook signature verification failed for account ${account}:`, e.message);
     return { statusCode:400, body:`bad sig: ${e.message}` };

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,3 +1,4 @@
+import Stripe from 'stripe';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
@@ -7,6 +8,28 @@ const ddb = DynamoDBDocumentClient.from(client);
 const ssm = new SSMClient({});
 
 const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE || 'MerchantsTable';
+const DEFAULT_TIMESTAMP_TOLERANCE_SECONDS = Number(
+  process.env.STRIPE_WEBHOOK_TIMESTAMP_TOLERANCE ?? '300'
+);
+
+let cachedStripeClient: Stripe | null = null;
+
+function getStripeClient(): Stripe {
+  if (!cachedStripeClient) {
+    cachedStripeClient = new Stripe(process.env.STRIPE_SECRET!, {
+      apiVersion: '2025-07-30.basil'
+    });
+  }
+
+  return cachedStripeClient;
+}
+
+function extractTimestamp(signature: string): number | null {
+  const match = signature.match(/t=(\d+)/);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
 
 /**
  * Get the webhook secret for a specific merchant account
@@ -80,29 +103,44 @@ async function getGlobalWebhookSecret(): Promise<string> {
 export async function validateWebhookSignature(
   payload: string | Buffer,
   signature: string,
-  accountId?: string
-): Promise<boolean> {
-  const Stripe = require('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
-  
+  accountId?: string,
+  options: { toleranceSeconds?: number; stripeClient?: Stripe } = {}
+): Promise<Stripe.Event> {
+  if (!signature) {
+    throw new Error('Missing Stripe-Signature header');
+  }
+
+  const timestamp = extractTimestamp(signature);
+  if (!timestamp) {
+    throw new Error('Stripe-Signature header missing timestamp');
+  }
+
+  const toleranceSeconds = options.toleranceSeconds ?? DEFAULT_TIMESTAMP_TOLERANCE_SECONDS;
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > toleranceSeconds) {
+    throw new Error(`Webhook signature timestamp outside of tolerance (${toleranceSeconds}s)`);
+  }
+
+  const stripe = options.stripeClient ?? getStripeClient();
+
   try {
     // Get the appropriate webhook secret
-    const webhookSecret = accountId 
+    const webhookSecret = accountId
       ? await getMerchantWebhookSecret(accountId)
       : await getGlobalWebhookSecret();
-    
+
     // Verify the webhook signature
     const event = stripe.webhooks.constructEvent(
       payload,
       signature,
       webhookSecret
     );
-    
+
     console.log(`[WEBHOOK] Signature validated for event ${event.id}`);
-    return true;
+    return event;
   } catch (error) {
     console.error('[WEBHOOK] Signature validation failed:', error);
-    return false;
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- add caching for the Stripe client and configurable timestamp tolerance when validating webhook signatures
- parse the Stripe-Signature header timestamp and reject stale requests before constructing the event
- update the main webhook handler to rely on the shared validator for signature and timestamp checks

## Testing
- npm run build *(fails: src/handlers/buildEvidence.ts:207:23 - error TS2339: Property 'fraudWarning' does not exist on type 'EvidencePackage'.)*

------
https://chatgpt.com/codex/tasks/task_e_68deef402534832fa91c8537b863dc2c