### PR TITLE
Add audit coverage for data mutations and security incidents

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -42,7 +42,7 @@ export async function handler(event:any){
   }
 
   // Save all OAuth data to DynamoDB
-  await putMerchant({ 
+  await putMerchant({
     merchant_id,
     stripe_account_id: merchant_id,
     access_token, // CRITICAL: Save this for API calls
@@ -53,6 +53,17 @@ export async function handler(event:any){
     livemode,
     firebase_uid, // Link to Firebase user
     oauth_connected_at: new Date().toISOString()
+  }, {
+    action: AuditAction.OAUTH_CONNECT,
+    userId: firebase_uid || undefined,
+    merchantId: merchant_id,
+    ipAddress: event.requestContext?.identity?.sourceIp,
+    userAgent: event.requestContext?.identity?.userAgent,
+    metadata: {
+      scope,
+      livemode,
+      stripe_publishable_key
+    }
   });
   
   // Audit successful OAuth connection
@@ -93,6 +104,13 @@ export async function handler(event:any){
       merchant_id,
       webhook_endpoint_id: webhookEndpoint.id,
       webhook_secret: webhookEndpoint.secret
+    }, {
+      action: AuditAction.SETTINGS_UPDATED,
+      merchantId: merchant_id,
+      userId: firebase_uid || undefined,
+      metadata: {
+        webhookEndpointId: webhookEndpoint.id
+      }
     });
   } catch (webhookError) {
     console.error('Failed to register webhook:', webhookError);

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,7 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { AuditAction } from "../shared/auditLog.js";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -64,6 +65,12 @@ export async function handler(event: any) {
               access_token: json.access_token,
               refresh_token: json.refresh_token || merchant.refresh_token,
               token_refreshed_at: new Date().toISOString()
+            }, {
+              action: AuditAction.OAUTH_TOKEN_REFRESH,
+              merchantId: merchant.merchant_id,
+              metadata: {
+                source: 'autoRefreshTokens'
+              }
             });
             
             results.refreshed++;

--- a/src/handlers/buildEvidence.ts
+++ b/src/handlers/buildEvidence.ts
@@ -8,6 +8,7 @@ import {
 import { CloudWatch, StandardUnit } from '@aws-sdk/client-cloudwatch';
 import { ddb } from "../shared/ddb";
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { auditDataMutation, AuditAction } from "../shared/auditLog.js";
 
 // ML Enhancement Imports (Safe - with fallbacks)
 let patternCache: any = null;
@@ -318,6 +319,18 @@ export async function handler(evt:any){
           }
         }));
         console.log(`📊 ML: Stored prediction for dispute ${dispute.id}: ${(evidencePackage.winProbability * 100).toFixed(1)}%`);
+
+        await auditDataMutation({
+          action: AuditAction.EVIDENCE_COLLECTED,
+          resourceType: 'ml_prediction',
+          resourceId: dispute.id,
+          merchantId: merchant.stripe_account_id,
+          metadata: {
+            modelVersion: 'heuristic-v1',
+            probability: evidencePackage.winProbability,
+            ce3Eligible: evidencePackage.ce3Eligible
+          }
+        });
       } catch (error) {
         console.error('Failed to store ML prediction:', error);
       }

--- a/src/handlers/getDispute.ts
+++ b/src/handlers/getDispute.ts
@@ -1,5 +1,6 @@
 import Stripe from 'stripe';
 import { getMerchantByAccount, upsertCase } from "../shared/db.js";
+import { AuditAction } from "../shared/auditLog.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
 
@@ -8,6 +9,12 @@ export async function handler(evt:any){
   const merchant = await getMerchantByAccount(stripe_account_id);
   const d = await stripe.disputes.retrieve(dispute_id, { stripeAccount: stripe_account_id });
   const tMinus = d.evidence_details?.due_by ? new Date((d.evidence_details.due_by*1000) - (48*3600*1000)).toISOString() : null;
-  await upsertCase(stripe_account_id, d, {});
+  await upsertCase(stripe_account_id, d, {}, {
+    action: AuditAction.DISPUTE_UPDATED,
+    merchantId: stripe_account_id,
+    metadata: {
+      source: 'getDisputeHandler'
+    }
+  });
   return { ...evt, dispute: d, merchant, "dispute.evidence_details.due_by_minus_48h": tMinus };
 }

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { AuditAction } from "../shared/auditLog.js";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -52,6 +53,14 @@ export async function handler(event: any) {
       access_token: json.access_token,
       refresh_token: json.refresh_token || merchant.refresh_token, // Use new refresh token if provided
       token_refreshed_at: new Date().toISOString()
+    }, {
+      action: AuditAction.OAUTH_TOKEN_REFRESH,
+      merchantId: authContext.merchant_id,
+      userId: authContext.uid,
+      userEmail: authContext.email,
+      metadata: {
+        source: 'manualRefresh'
+      }
     });
     
     return ok({

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -85,6 +85,14 @@ async function handleSubscriptionCreated(merchantId: string, subscription: any) 
     subscription_created_at: new Date(subscription.created * 1000).toISOString(),
     plan_id: subscription.items?.data?.[0]?.price?.id,
     customer_id: subscription.customer
+  }, {
+    action: AuditAction.SUBSCRIPTION_CREATED,
+    merchantId,
+    metadata: {
+      subscriptionId: subscription.id,
+      status: subscription.status,
+      event: 'handleSubscriptionCreated'
+    }
   });
   
   // If this is the first paid subscription, activate premium features
@@ -103,6 +111,14 @@ async function handleSubscriptionUpdated(merchantId: string, subscription: any) 
     subscription_current_period_end: subscription.current_period_end,
     subscription_cancel_at_period_end: subscription.cancel_at_period_end,
     plan_id: subscription.items?.data?.[0]?.price?.id
+  }, {
+    action: AuditAction.SUBSCRIPTION_UPDATED,
+    merchantId,
+    metadata: {
+      subscriptionId: subscription.id,
+      status: subscription.status,
+      event: 'handleSubscriptionUpdated'
+    }
   });
   
   // Handle status changes
@@ -124,6 +140,13 @@ async function handleSubscriptionDeleted(merchantId: string, subscription: any) 
     subscription_status: 'canceled',
     subscription_canceled_at: new Date().toISOString(),
     premium_features_active: false
+  }, {
+    action: AuditAction.SUBSCRIPTION_CANCELLED,
+    merchantId,
+    metadata: {
+      subscriptionId: subscription.id,
+      event: 'handleSubscriptionDeleted'
+    }
   });
   
   // Deactivate premium features
@@ -138,6 +161,13 @@ async function handleTrialWillEnd(merchantId: string, subscription: any) {
   await putMerchant({
     merchant_id: merchantId,
     trial_ending_notification_sent: new Date().toISOString()
+  }, {
+    action: AuditAction.SUBSCRIPTION_UPDATED,
+    merchantId,
+    metadata: {
+      subscriptionId: subscription.id,
+      event: 'handleTrialWillEnd'
+    }
   });
 }
 
@@ -149,6 +179,13 @@ async function handleSubscriptionPaused(merchantId: string, subscription: any) {
     subscription_status: 'paused',
     subscription_paused_at: new Date().toISOString(),
     premium_features_active: false
+  }, {
+    action: AuditAction.SUBSCRIPTION_UPDATED,
+    merchantId,
+    metadata: {
+      subscriptionId: subscription.id,
+      event: 'handleSubscriptionPaused'
+    }
   });
   
   // Temporarily deactivate features
@@ -163,6 +200,13 @@ async function handleSubscriptionResumed(merchantId: string, subscription: any) 
     subscription_status: 'active',
     subscription_resumed_at: new Date().toISOString(),
     premium_features_active: true
+  }, {
+    action: AuditAction.SUBSCRIPTION_UPDATED,
+    merchantId,
+    metadata: {
+      subscriptionId: subscription.id,
+      event: 'handleSubscriptionResumed'
+    }
   });
   
   // Reactivate features
@@ -177,6 +221,12 @@ async function handlePastDueSubscription(merchantId: string) {
     merchant_id: merchantId,
     premium_features_limited: true,
     past_due_notification_sent: new Date().toISOString()
+  }, {
+    action: AuditAction.SUBSCRIPTION_UPDATED,
+    merchantId,
+    metadata: {
+      event: 'handlePastDueSubscription'
+    }
   });
 }
 
@@ -193,6 +243,12 @@ async function activatePremiumFeatures(merchantId: string) {
     api_rate_limit: 10000, // Premium rate limit
     max_disputes_per_month: -1, // Unlimited
     features_activated_at: new Date().toISOString()
+  }, {
+    action: AuditAction.SETTINGS_UPDATED,
+    merchantId,
+    metadata: {
+      event: 'activatePremiumFeatures'
+    }
   });
 }
 
@@ -209,6 +265,12 @@ async function deactivatePremiumFeatures(merchantId: string) {
     api_rate_limit: 100, // Free tier rate limit
     max_disputes_per_month: 10, // Free tier limit
     features_deactivated_at: new Date().toISOString()
+  }, {
+    action: AuditAction.SETTINGS_UPDATED,
+    merchantId,
+    metadata: {
+      event: 'deactivatePremiumFeatures'
+    }
   });
 }
 
@@ -331,6 +393,15 @@ export async function cancelSubscription(event: any) {
       merchant_id: merchantId,
       subscription_cancel_at_period_end: true,
       subscription_cancel_requested_at: new Date().toISOString()
+    }, {
+      action: AuditAction.SUBSCRIPTION_CANCELLED,
+      merchantId,
+      userId: authContext.uid,
+      userEmail: authContext.email,
+      metadata: {
+        event: 'cancelSubscriptionRequest',
+        subscriptionId: merchant.subscription_id
+      }
     });
     
     // Audit the cancellation

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -5,6 +5,7 @@ import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
 import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { auditSecurityEvent, AuditAction, auditDataMutation } from "../shared/auditLog.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -103,6 +104,16 @@ async function markEventProcessed(eventId: string, eventType: string): Promise<v
         ttl: Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60) // TTL: 7 days
       }
     }));
+
+    await auditDataMutation({
+      action: AuditAction.WEBHOOK_RECEIVED,
+      resourceType: 'webhook_event',
+      resourceId: eventId,
+      metadata: {
+        eventType,
+        source: 'webhookStripe.markEventProcessed'
+      }
+    });
   } catch (error) {
     console.error('Error marking event as processed:', error);
   }
@@ -128,6 +139,7 @@ export async function handler(event:any){
     evt = stripe.webhooks.constructEvent(rawBody, sig!, webhookSecret);
   }catch(e:any){
     console.error(`Webhook signature verification failed for account ${account}:`, e.message);
+    await auditSecurityEvent(event, AuditAction.UNAUTHORIZED_ACCESS, `Webhook signature verification failed: ${e.message}`);
     return { statusCode:400, body:`bad sig: ${e.message}` };
   }
 
@@ -159,6 +171,14 @@ export async function handler(event:any){
           type: 'subscription',
           firebase_uid: session.metadata?.firebase_uid || session.client_reference_id,
           updated_at: new Date().toISOString()
+        }, {
+          action: AuditAction.SUBSCRIPTION_CREATED,
+          merchantId: 'SYSTEM',
+          metadata: {
+            eventId: evt.id,
+            eventType: evt.type,
+            subscriptionId: session.subscription
+          }
         });
         
         console.log('Subscription linked to user:', session.client_reference_id);
@@ -250,6 +270,17 @@ export async function handler(event:any){
         customer_email,
         event_type: evt.type,
         updated_at: new Date().toISOString()
+      }, {
+        action: evt.type === 'customer.subscription.created'
+          ? AuditAction.SUBSCRIPTION_CREATED
+          : AuditAction.SUBSCRIPTION_UPDATED,
+        merchantId: 'SYSTEM',
+        metadata: {
+          firebase_uid,
+          customer_email,
+          eventType: evt.type,
+          subscriptionId: subscription.id
+        }
       });
       
       // Store subscription history for audit trail
@@ -263,6 +294,15 @@ export async function handler(event:any){
         timestamp: new Date().toISOString()
       }, {
         type: 'subscription_history'
+      }, {
+        action: AuditAction.SUBSCRIPTION_UPDATED,
+        merchantId: 'SYSTEM',
+        metadata: {
+          firebase_uid,
+          eventType: evt.type,
+          subscriptionId: subscription.id,
+          history: true
+        }
       });
       
       console.log(`Subscription ${action} for user ${firebase_uid}: ${subscription.status} (access: ${userAccess})`);
@@ -361,6 +401,17 @@ export async function handler(event:any){
       } : null,
       riskLevel,
       aiEnhanced: !!aiAnalysis
+    }, {
+      action: evt.type === 'charge.dispute.created'
+        ? AuditAction.DISPUTE_CREATED
+        : AuditAction.DISPUTE_UPDATED,
+      merchantId: eventAccount!,
+      metadata: {
+        eventType: evt.type,
+        disputeStatus: dispute.status,
+        riskLevel,
+        aiEnhanced: !!aiAnalysis
+      }
     });
     
     if(evt.type === 'charge.dispute.created'){

--- a/src/shared/auditLog.ts
+++ b/src/shared/auditLog.ts
@@ -95,6 +95,38 @@ export async function createAuditLog(entry: Omit<AuditLogEntry, 'id' | 'timestam
   }
 }
 
+export interface DataMutationAuditInput {
+  action: AuditAction;
+  resourceType: string;
+  resourceId: string;
+  userId?: string;
+  userEmail?: string;
+  merchantId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  correlationId?: string;
+  metadata?: Record<string, any>;
+  success?: boolean;
+  errorMessage?: string;
+}
+
+export async function auditDataMutation(input: DataMutationAuditInput): Promise<void> {
+  await createAuditLog({
+    action: input.action,
+    userId: input.userId,
+    userEmail: input.userEmail,
+    merchantId: input.merchantId,
+    resourceType: input.resourceType,
+    resourceId: input.resourceId,
+    ipAddress: input.ipAddress,
+    userAgent: input.userAgent,
+    correlationId: input.correlationId,
+    success: input.success ?? true,
+    errorMessage: input.errorMessage,
+    metadata: input.metadata
+  });
+}
+
 /**
  * Audit middleware for Lambda handlers
  */

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "./ddb.js";
+import { auditSecurityEvent, AuditAction } from "./auditLog.js";
 
 // Initialize Firebase Admin SDK
 let firebaseApp: admin.app.App | null = null;
@@ -90,8 +91,12 @@ export async function validateAuth(authHeader: string | undefined): Promise<Auth
 export async function requireAuth(event: any): Promise<AuthContext | { statusCode: number; body: string }> {
   const authHeader = event.headers?.Authorization || event.headers?.authorization;
   const authContext = await validateAuth(authHeader);
-  
+
   if (!authContext) {
+    const detail = !authHeader || !authHeader.startsWith('Bearer ')
+      ? 'Missing or malformed Authorization header'
+      : 'Invalid or expired authentication token';
+    await auditSecurityEvent(event, AuditAction.UNAUTHORIZED_ACCESS, detail);
     return {
       statusCode: 401,
       body: JSON.stringify({ error: 'Unauthorized' })

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,10 +1,22 @@
 import { ddb } from "./ddb.js";
 import { PutCommand, GetCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { auditDataMutation, AuditAction } from "./auditLog.js";
 
 const MERCHANTS = process.env.MERCHANTS_TABLE!;
 const CASES = process.env.CASES_TABLE!;
 
-export async function putMerchant(m:any){
+interface MutationAuditContext {
+  action?: AuditAction;
+  userId?: string;
+  userEmail?: string;
+  merchantId?: string;
+  correlationId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  metadata?: Record<string, any>;
+}
+
+export async function putMerchant(m:any, auditContext: MutationAuditContext = {}){
   // Use stripe_account_id as the primary key for consistency
   const merchant_id = m.stripe_account_id || m.merchant_id;
   const item = {
@@ -15,6 +27,22 @@ export async function putMerchant(m:any){
     created_at: m.created_at || new Date().toISOString()
   };
   await ddb.send(new PutCommand({ TableName: MERCHANTS, Item: item }));
+
+  await auditDataMutation({
+    action: auditContext.action ?? AuditAction.SETTINGS_UPDATED,
+    resourceType: 'merchant',
+    resourceId: merchant_id,
+    userId: auditContext.userId,
+    userEmail: auditContext.userEmail,
+    merchantId: auditContext.merchantId ?? merchant_id,
+    correlationId: auditContext.correlationId,
+    ipAddress: auditContext.ipAddress,
+    userAgent: auditContext.userAgent,
+    metadata: {
+      updatedFields: Object.keys(m),
+      ...auditContext.metadata
+    }
+  });
 }
 
 export async function getMerchantByAccount(stripe_account_id:string){
@@ -23,7 +51,7 @@ export async function getMerchantByAccount(stripe_account_id:string){
   return r.Item || { pk, merchant_id: stripe_account_id, stripe_account_id, settings: { autoSubmit: true, autoAcceptBelowCents: 0, retentionDays: 540, notifyEmails: [] } };
 }
 
-export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
+export async function upsertCase(merchantId:string, dispute:any, extras:any={}, auditContext: MutationAuditContext = {}){
   const now = Math.floor(Date.now()/1000);
   const item = {
     pk: `MERCHANT#${merchantId}`,
@@ -46,6 +74,28 @@ export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
     ...extras
   };
   await ddb.send(new PutCommand({ TableName: CASES, Item: item }));
+
+  const inferredAction = extras?.type === 'subscription'
+    ? AuditAction.SUBSCRIPTION_UPDATED
+    : AuditAction.DISPUTE_UPDATED;
+
+  await auditDataMutation({
+    action: auditContext.action ?? inferredAction,
+    resourceType: extras?.type === 'subscription' ? 'subscription' : 'case',
+    resourceId: dispute.id,
+    userId: auditContext.userId,
+    userEmail: auditContext.userEmail,
+    merchantId: auditContext.merchantId ?? merchantId,
+    correlationId: auditContext.correlationId,
+    ipAddress: auditContext.ipAddress,
+    userAgent: auditContext.userAgent,
+    metadata: {
+      status: dispute.status,
+      disputeReason: dispute.reason,
+      updatedFields: Object.keys({ ...dispute, ...extras }),
+      ...auditContext.metadata
+    }
+  });
   return item;
 }
 

--- a/src/shared/rateLimit.ts
+++ b/src/shared/rateLimit.ts
@@ -1,6 +1,7 @@
 import { createErrorResponse } from './responses.js';
 import { ddb } from './ddb.js';
 import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { auditSecurityEvent, AuditAction } from './auditLog.js';
 
 const RATE_LIMIT_TABLE = process.env.CASES_TABLE!; // Reuse cases table
 
@@ -101,6 +102,7 @@ export async function rateLimitMiddleware(event: any): Promise<any> {
   const allowed = await checkRateLimit(config);
   
   if (!allowed) {
+    await auditSecurityEvent(event, AuditAction.RATE_LIMITED, `Rate limit exceeded for ${config.identifier}`);
     return createErrorResponse(429, 'Too Many Requests', {
       message: 'Rate limit exceeded. Please try again later.',
       retryAfter: config.windowSeconds

--- a/src/shared/webhookIdempotency.ts
+++ b/src/shared/webhookIdempotency.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { auditDataMutation, AuditAction } from './auditLog.js';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
@@ -57,8 +58,19 @@ export class WebhookIdempotencyService {
           metadata: metadata || {}
         }
       }));
-      
+
       console.log(`[IDEMPOTENCY] Marked webhook as processed: ${eventId}`);
+
+      await auditDataMutation({
+        action: metadata?.success === false ? AuditAction.ERROR_OCCURRED : AuditAction.WEBHOOK_RECEIVED,
+        resourceType: 'webhook_event',
+        resourceId: eventId,
+        merchantId: metadata?.merchantId,
+        metadata: {
+          ...metadata,
+          source: 'idempotency'
+        }
+      });
     } catch (error) {
       console.error('[IDEMPOTENCY] Error marking processed:', error);
       // Continue processing even if we can't mark it

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { auditDataMutation, AuditAction } from './auditLog.js';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
@@ -134,6 +135,17 @@ export async function storeWebhookSecret(
     }));
     
     console.log(`[WEBHOOK] Stored webhook secret for merchant ${merchantId}`);
+
+    await auditDataMutation({
+      action: AuditAction.SETTINGS_UPDATED,
+      resourceType: 'merchant_webhook',
+      resourceId: merchantId,
+      merchantId,
+      metadata: {
+        webhookEndpointId,
+        event: 'storeWebhookSecret'
+      }
+    });
   } catch (error) {
     console.error('[WEBHOOK] Error storing webhook secret:', error);
     throw error;


### PR DESCRIPTION
## Summary
- add a reusable auditDataMutation helper and invoke it from merchant/case persistence code and supporting handlers
- record audit security events for authentication failures, rate limiting, and webhook signature problems while enriching webhook logging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deef145980832f962a581d9c1855c2