### PR TITLE
Add centralized CORS and security headers across handlers

### DIFF
--- a/src/handlers/authLoginHandler.ts
+++ b/src/handlers/authLoginHandler.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import jwt from 'jsonwebtoken';
-import crypto from 'crypto';
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from '../shared/responses.js';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'stripedshield-demo-secret-2025';
 const JWT_EXPIRY = '7d'; // 7 days validity
@@ -43,22 +43,11 @@ const DEMO_USERS = [
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
-  
-  // CORS headers
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
-    'Access-Control-Allow-Methods': 'POST,OPTIONS'
-  };
+  const origin = getRequestOrigin(event);
 
-  // Handle OPTIONS request for CORS
-  if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 200,
-      headers,
-      body: ''
-    };
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) {
+    return preflight;
   }
 
   try {
@@ -68,26 +57,18 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     try {
       loginRequest = JSON.parse(event.body || '{}');
     } catch (error) {
-      return {
-        statusCode: 400,
-        headers,
-        body: JSON.stringify({
-          success: false,
-          error: 'Invalid request body'
-        })
-      };
+      return jsonResponse(400, {
+        success: false,
+        error: 'Invalid request body'
+      }, { origin });
     }
 
     // Validate email
     if (!loginRequest.email) {
-      return {
-        statusCode: 400,
-        headers,
-        body: JSON.stringify({
-          success: false,
-          error: 'Email is required'
-        })
-      };
+      return jsonResponse(400, {
+        success: false,
+        error: 'Email is required'
+      }, { origin });
     }
 
     // Normalize email
@@ -128,25 +109,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         expiresIn: JWT_EXPIRY
       };
 
-      return {
-        statusCode: 200,
-        headers,
-        body: JSON.stringify(response)
-      };
+      return jsonResponse(200, response, { origin });
     }
 
     // For other users, check password
     if (demoUser) {
       // Validate password
       if (!loginRequest.password || loginRequest.password !== demoUser.password) {
-        return {
-          statusCode: 401,
-          headers,
-          body: JSON.stringify({
-            success: false,
-            error: 'Invalid email or password'
-          })
-        };
+        return jsonResponse(401, {
+          success: false,
+          error: 'Invalid email or password'
+        }, { origin });
       }
 
       // Generate JWT token
@@ -178,34 +151,22 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         expiresIn: JWT_EXPIRY
       };
 
-      return {
-        statusCode: 200,
-        headers,
-        body: JSON.stringify(response)
-      };
+      return jsonResponse(200, response, { origin });
     }
 
     // For production, would check against DynamoDB
     // For now, return error for unknown users
-    return {
-      statusCode: 401,
-      headers,
-      body: JSON.stringify({
-        success: false,
-        error: 'Invalid email or password'
-      })
-    };
+    return jsonResponse(401, {
+      success: false,
+      error: 'Invalid email or password'
+    }, { origin });
 
   } catch (error) {
     console.error('Error in auth login handler:', error);
     
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({
-        success: false,
-        error: 'Internal server error'
-      })
-    };
+    return jsonResponse(500, {
+      success: false,
+      error: 'Internal server error'
+    }, { origin });
   }
 };

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,13 +1,18 @@
 import { putMerchant } from "../shared/db.js";
 import Stripe from 'stripe';
-import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { createAuditLog, AuditAction } from "../shared/auditLog.js";
+import { createErrorResponse, getRequestOrigin, handleCorsPreflight, redirect } from "../shared/responses.js";
 
 export async function handler(event:any){
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   const qs = event.queryStringParameters || {};
   const code = qs.code;
   const state = qs.state; // Should contain firebase_uid
-  
-  if(!code) return { statusCode:400, body:'missing code' };
+
+  if(!code) return createErrorResponse(400, 'Missing code parameter', undefined, { origin });
 
   const body = new URLSearchParams({
     client_secret: process.env.STRIPE_SECRET!,
@@ -19,7 +24,9 @@ export async function handler(event:any){
     method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
   });
   const json:any = await r.json();
-  if(!json.stripe_user_id) return { statusCode:400, body:`oauth failed: ${JSON.stringify(json)}` };
+  if(!json.stripe_user_id) {
+    return createErrorResponse(400, 'OAuth failed', { details: json }, { origin });
+  }
 
   // Extract all OAuth data
   const merchant_id = json.stripe_user_id;
@@ -101,5 +108,5 @@ export async function handler(event:any){
 
   // Redirect to frontend connect page with success
   const frontendCallbackUrl = `https://stripedshield-founders-1755231149.netlify.app/connect.html?success=true&stripe_account_id=${merchant_id}${firebase_uid ? '&uid=' + firebase_uid : ''}`;
-  return { statusCode: 302, headers: { Location: frontendCallbackUrl }, body: '' };
+  return redirect(frontendCallbackUrl, 302, { origin });
 }

--- a/src/handlers/authStripeStart.ts
+++ b/src/handlers/authStripeStart.ts
@@ -1,11 +1,15 @@
 import crypto from 'crypto';
-import { ok, bad } from "../shared/responses.js";
+import { bad, getRequestOrigin, handleCorsPreflight, redirect } from "../shared/responses.js";
 
 const STRIPE_CLIENT_ID = process.env.STRIPE_CLIENT_ID!;
 const STRIPE_REDIRECT_URI = process.env.STRIPE_REDIRECT_URI!;
 
 export async function handler(event: any){
-  if(!STRIPE_CLIENT_ID || !STRIPE_REDIRECT_URI) return bad("Stripe not configured");
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
+  if(!STRIPE_CLIENT_ID || !STRIPE_REDIRECT_URI) return bad("Stripe not configured", { origin });
   
   // Get Firebase UID from query parameters to link accounts
   const qs = event.queryStringParameters || {};
@@ -30,12 +34,14 @@ export async function handler(event: any){
   }).toString();
   
   // Return 302 redirect instead of 200 with URL
-  return {
-    statusCode: 302,
-    headers: {
-      'Location': `https://connect.stripe.com/oauth/authorize?${params}`,
-      'Cache-Control': 'no-cache, no-store, must-revalidate'
-    },
-    body: ''
-  };
+  return redirect(
+    `https://connect.stripe.com/oauth/authorize?${params}`,
+    302,
+    {
+      origin,
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate'
+      }
+    }
+  );
 }

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,7 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { createErrorResponse, jsonResponse } from "../shared/responses.js";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -81,16 +82,10 @@ export async function handler(event: any) {
     
     console.log('Token refresh results:', results);
     
-    return {
-      statusCode: 200,
-      body: JSON.stringify(results)
-    };
-    
+    return jsonResponse(200, results);
+
   } catch (error: any) {
     console.error('Auto refresh error:', error);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: error.message })
-    };
+    return createErrorResponse(500, 'Auto refresh error', { message: error.message });
   }
 }

--- a/src/handlers/buildEvidence.ts
+++ b/src/handlers/buildEvidence.ts
@@ -204,7 +204,7 @@ export async function handler(evt:any){
     // Apply ML optimizations if available
     if (mlOptimizedEvidence && fraudDetected) {
       console.log('🚨 ML: Fraud detected, adding extra verification evidence');
-      evidencePackage.fraudWarning = true;
+      (evidencePackage as any).fraudWarning = true;
     }
     
     // Extract the evidence object for Stripe submission

--- a/src/handlers/collectCase.ts
+++ b/src/handlers/collectCase.ts
@@ -1,11 +1,14 @@
-import { bad } from "../shared/responses.js";
+import { bad, createErrorResponse, getRequestOrigin, handleCorsPreflight, jsonResponse } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
-import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { StartExecutionCommand, SFNClient as StepFunctionsClient } from "@aws-sdk/client-sfn";
 
 const sfn = new StepFunctionsClient({});
 
 export async function handler(event:any){
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -17,15 +20,12 @@ export async function handler(event:any){
   const qs = event.queryStringParameters || {};
   const merchantId = qs.merchant || authContext.merchant_id;
   
-  if(!merchantId || !id) return bad("missing merchant or id");
+  if(!merchantId || !id) return bad("missing merchant or id", { origin });
   
   // VERIFY USER OWNS THIS MERCHANT ACCOUNT
   const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
   if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
+    return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
   }
 
   await sfn.send(new StartExecutionCommand({
@@ -33,5 +33,5 @@ export async function handler(event:any){
     input: JSON.stringify({ merchant: { stripe_account_id: merchantId }, dispute_id: id })
   }));
 
-  return { statusCode:202, body:'started' };
+  return jsonResponse(202, { status: 'started' }, { origin });
 }

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -1,10 +1,14 @@
 import Stripe from 'stripe';
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
   // Get auth context if user is logged in (optional for checkout)
   let authContext = null;
   try {
@@ -21,7 +25,7 @@ export async function handler(event: any) {
   const priceId = body.price_id || process.env.STRIPE_PRICE_ID || 'price_1QWtQxDOwkStzJVXK8PqXJ0z'; // Default founder price
   
   if (!email) {
-    return bad('Email is required');
+    return bad('Email is required', { origin });
   }
   
   try {
@@ -69,13 +73,13 @@ export async function handler(event: any) {
       }
     });
     
-    return ok({ 
+    return ok({
       checkout_url: session.url,
       session_id: session.id
-    });
-    
+    }, { origin });
+
   } catch (error: any) {
     console.error('Checkout session error:', error);
-    return bad(error.message);
+    return bad(error.message, { origin });
   }
 }

--- a/src/handlers/debugRedis.ts
+++ b/src/handlers/debugRedis.ts
@@ -1,11 +1,18 @@
 import Redis from 'ioredis';
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from '../shared/responses.js';
 
 /**
  * Debug endpoint to test Redis connectivity
  * Helps diagnose Redis connection issues
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) {
+    return preflight;
+  }
+
   try {
     const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
     
@@ -33,21 +40,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     // Mask password in URL for security
     const safeUrl = redisUrl.replace(/:[^:@]*@/, ':***@');
     
-    return {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-cache'
-      },
-      body: JSON.stringify({
-        status: 'connected',
-        pong,
-        latencyMs: ms,
-        redisUrl: safeUrl,
-        redisVersion: version,
-        timestamp: new Date().toISOString()
-      }, null, 2)
-    };
+    return jsonResponse(200, {
+      status: 'connected',
+      pong,
+      latencyMs: ms,
+      redisUrl: safeUrl,
+      redisVersion: version,
+      timestamp: new Date().toISOString()
+    }, {
+      origin,
+      headers: { 'Cache-Control': 'no-cache' }
+    });
     
   } catch (error: any) {
     console.error('Redis debug error:', error);
@@ -55,18 +58,14 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     // Mask any sensitive data in error messages
     const safeError = error.message.replace(/:[^:@]*@/, ':***@');
     
-    return {
-      statusCode: 503,
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-cache'
-      },
-      body: JSON.stringify({
-        status: 'error',
-        error: safeError,
-        redisUrl: process.env.REDIS_URL ? 'configured' : 'not configured',
-        timestamp: new Date().toISOString()
-      }, null, 2)
-    };
+    return jsonResponse(503, {
+      status: 'error',
+      error: safeError,
+      redisUrl: process.env.REDIS_URL ? 'configured' : 'not configured',
+      timestamp: new Date().toISOString()
+    }, {
+      origin,
+      headers: { 'Cache-Control': 'no-cache' }
+    });
   }
 };

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -3,6 +3,7 @@ import { requireAuth, verifyMerchantOwnership } from '../shared/auth.js';
 import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
 import Stripe from 'stripe';
+import { createErrorResponse, getRequestOrigin, handleCorsPreflight, jsonResponse } from '../shared/responses.js';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -31,22 +32,11 @@ interface Dispute {
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
-  
-  // CORS headers
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
-    'Access-Control-Allow-Methods': 'GET,OPTIONS'
-  };
+  const origin = getRequestOrigin(event);
 
-  // Handle OPTIONS request for CORS
-  if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 200,
-      headers,
-      body: ''
-    };
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) {
+    return preflight;
   }
 
   try {
@@ -60,7 +50,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     if (validationResult) {
       return validationResult; // Return 400 if validation fails
     }
-    
+
     // REQUIRE AUTHENTICATION
     const authResult = await requireAuth(event);
     if ('statusCode' in authResult) {
@@ -73,21 +63,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     let merchantId = input.merchant || authContext.merchant_id || '';
     
     if (!merchantId) {
-      return {
-        statusCode: 400,
-        headers,
-        body: JSON.stringify({ error: 'No merchant account specified or connected' })
-      };
+      return createErrorResponse(400, 'No merchant account specified or connected', undefined, { origin });
     }
     
     // VERIFY USER OWNS THIS MERCHANT ACCOUNT
     const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
     if (!hasAccess) {
-      return {
-        statusCode: 403,
-        headers,
-        body: JSON.stringify({ error: 'Access denied to this merchant account' })
-      };
+      return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
     }
     
     // Get REAL disputes from Stripe
@@ -139,33 +121,25 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     
     const processingTime = Date.now() - startTime;
     
-    return {
-      statusCode: 200,
-      headers,
-      body: JSON.stringify({
-        success: true,
-        authenticated: true,
-        merchant_id: merchantId,
-        data: {
-          disputes,
-          summary
-        },
-        processingTime: `${processingTime}ms`,
-        timestamp: new Date().toISOString()
-      })
-    };
-    
+    return jsonResponse(200, {
+      success: true,
+      authenticated: true,
+      merchant_id: merchantId,
+      data: {
+        disputes,
+        summary
+      },
+      processingTime: `${processingTime}ms`,
+      timestamp: new Date().toISOString()
+    }, { origin });
+
   } catch (error) {
     console.error('Error in disputes handler:', error);
-    
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({
-        success: false,
-        error: 'Internal server error',
-        processingTime: `${Date.now() - startTime}ms`
-      })
-    };
+
+    return jsonResponse(500, {
+      success: false,
+      error: 'Internal server error',
+      processingTime: `${Date.now() - startTime}ms`
+    }, { origin });
   }
 };

--- a/src/handlers/getCase.ts
+++ b/src/handlers/getCase.ts
@@ -1,9 +1,13 @@
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, createErrorResponse, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { validationMiddleware, commonSchemas } from "../shared/validation.js";
 
 export async function handler(event:any){
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   // Validate input first
   const validationSchema = {
     ...commonSchemas.disputeId,
@@ -31,17 +35,14 @@ export async function handler(event:any){
     merchantId = authContext.merchant_id;
   }
   
-  if(!merchantId) return bad("missing merchant param or no connected Stripe account");
+  if(!merchantId) return bad("missing merchant param or no connected Stripe account", { origin });
   
   // VERIFY USER OWNS THIS MERCHANT ACCOUNT
   const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
   if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
+    return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
   }
-  
+
   const item = await getCase(merchantId, id);
-  return ok({ item });
+  return ok({ item }, { origin });
 }

--- a/src/handlers/getUserDisputes.ts
+++ b/src/handlers/getUserDisputes.ts
@@ -1,4 +1,4 @@
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { listCases } from "../shared/db.js";
 import { requireAuth } from "../shared/auth.js";
 
@@ -7,6 +7,10 @@ import { requireAuth } from "../shared/auth.js";
  * No merchant parameter needed - uses user's own merchant account
  */
 export async function handler(event: any) {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -19,7 +23,7 @@ export async function handler(event: any) {
     return ok({
       items: [],
       message: 'No Stripe account connected. Please connect your Stripe account to see disputes.'
-    });
+    }, { origin });
   }
   
   // Get query parameters
@@ -58,10 +62,10 @@ export async function handler(event: any) {
       items: disputes,
       stats,
       merchant_id: authContext.merchant_id
-    });
-    
+    }, { origin });
+
   } catch (error: any) {
     console.error('Error fetching user disputes:', error);
-    return bad('Failed to fetch disputes: ' + error.message);
+    return bad('Failed to fetch disputes: ' + error.message, { origin });
   }
 }

--- a/src/handlers/health-minimal.ts
+++ b/src/handlers/health-minimal.ts
@@ -1,4 +1,5 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from "../shared/responses.js";
 
 // Minimal Redis check without heavy imports
 async function checkRedis(): Promise<{ ok: boolean; error?: string }> {
@@ -38,7 +39,11 @@ async function checkRedis(): Promise<{ ok: boolean; error?: string }> {
 
 const dynamo = new DynamoDBClient({});
 
-export const handler = async (_evt: any, ctx: any) => {
+export const handler = async (event: any, ctx: any) => {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   if (ctx && typeof ctx === 'object') {
     ctx.callbackWaitsForEmptyEventLoop = false;
   }
@@ -72,19 +77,15 @@ export const handler = async (_evt: any, ctx: any) => {
     }
   }
 
-  return {
-    statusCode: 200,
-    headers: { 
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*'
-    },
-    body: JSON.stringify({
-      ok: !degraded,
-      degraded,
-      checks,
-      service: 'StripedShield',
-      version: '2.0.1',
-      ts: new Date().toISOString()
-    })
-  };
+  return jsonResponse(200, {
+    ok: !degraded,
+    degraded,
+    checks,
+    service: 'StripedShield',
+    version: '2.0.1',
+    ts: new Date().toISOString()
+  }, {
+    origin,
+    headers: { 'Cache-Control': 'no-cache' }
+  });
 };

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { getRedisClient, isRedisReady } from "../cache/redisConnection";
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from "../shared/responses.js";
 
 const dynamo = new DynamoDBClient({});
 
@@ -9,7 +10,11 @@ const withTimeout = <T>(p: Promise<T>, ms = 350) =>
     new Promise<never>((_, rej) => setTimeout(() => rej(new Error("timeout")), ms))
   ]);
 
-export const handler = async (_evt: any, ctx: any) => {
+export const handler = async (event: any, ctx: any) => {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   if (ctx && typeof ctx === 'object') {
     ctx.callbackWaitsForEmptyEventLoop = false;
   }
@@ -52,19 +57,15 @@ export const handler = async (_evt: any, ctx: any) => {
     checks.dynamo = { ok: false, error: String(e?.message || e) };
   }
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-cache'
-    },
-    body: JSON.stringify({ 
-      ok: true, 
-      degraded, 
-      checks, 
-      service: 'StripedShield',
-      version: '2.0.1',
-      ts: new Date().toISOString() 
-    })
-  };
+  return jsonResponse(200, {
+    ok: true,
+    degraded,
+    checks,
+    service: 'StripedShield',
+    version: '2.0.1',
+    ts: new Date().toISOString()
+  }, {
+    origin,
+    headers: { 'Cache-Control': 'no-cache' }
+  });
 };

--- a/src/handlers/listCases.ts
+++ b/src/handlers/listCases.ts
@@ -1,4 +1,4 @@
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, createErrorResponse, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { listCases } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { rateLimitMiddleware } from "../shared/rateLimit.js";
@@ -21,6 +21,10 @@ function getRedis() {
 }
 
 export async function handler(event:any){
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   // Check rate limit first
   const rateLimitResult = await rateLimitMiddleware(event);
   if (rateLimitResult) {
@@ -54,15 +58,12 @@ export async function handler(event:any){
     merchantId = authContext.merchant_id;
   }
   
-  if(!merchantId) return bad("missing merchant param or no connected Stripe account");
+  if(!merchantId) return bad("missing merchant param or no connected Stripe account", { origin });
   
   // VERIFY USER OWNS THIS MERCHANT ACCOUNT
   const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
   if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
+    return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
   }
   
   // Try Redis cache first for performance
@@ -74,7 +75,7 @@ export async function handler(event:any){
       const cached = await redisClient.get(cacheKey);
       if (cached) {
         console.log(`[CACHE HIT] Returning cached cases for ${merchantId}`);
-        return ok(JSON.parse(cached));
+        return ok(JSON.parse(cached), { origin });
       }
     } catch (error) {
       console.warn('[CACHE] Redis read failed, falling back to DB:', error);
@@ -107,6 +108,6 @@ export async function handler(event:any){
       // Continue even if caching fails
     }
   }
-  
-  return ok(response);
+
+  return ok(response, { origin });
 }

--- a/src/handlers/metrics.ts
+++ b/src/handlers/metrics.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getRedisClient } from '../cache/redisConnection';
 import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from '../shared/responses.js';
 
 /**
  * Metrics endpoint for StripedShield
@@ -8,6 +9,12 @@ import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
  */
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
+  const origin = getRequestOrigin(event);
+
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) {
+    return preflight;
+  }
   
   try {
     // Get Redis client from connection manager
@@ -141,41 +148,37 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       responseTimeMs: Date.now() - startTime
     };
     
-    return {
-      statusCode: 200,
+    return jsonResponse(200, {
+      ...metrics,
+      degraded: false // Redis is available
+    }, {
+      origin,
       headers: {
-        'Content-Type': 'application/json',
         'Cache-Control': 'max-age=10',
         'X-StripedShield-Version': '2.0.0'
-      },
-      body: JSON.stringify({
-        ...metrics,
-        degraded: false // Redis is available
-      }, null, 2)
-    };
-    
+      }
+    });
+
   } catch (error: any) {
     console.error('Metrics error:', error);
-    
+
     // Return partial metrics with 200 status
-    return {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-cache'
-      },
-      body: JSON.stringify({
-        timestamp: new Date().toISOString(),
-        degraded: true, // Flag as degraded
-        error: 'Unable to fetch complete metrics',
-        message: error.message,
-        partial: {
-          winRate: {
-            current: 68.0,
-            definition: "Default value - Redis unavailable"
-          }
+    return jsonResponse(200, {
+      timestamp: new Date().toISOString(),
+      degraded: true, // Flag as degraded
+      error: 'Unable to fetch complete metrics',
+      message: error.message,
+      partial: {
+        winRate: {
+          current: 68.0,
+          definition: "Default value - Redis unavailable"
         }
-      })
-    };
+      }
+    }, {
+      origin,
+      headers: {
+        'Cache-Control': 'no-cache'
+      }
+    });
   }
 };

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
 
@@ -7,15 +7,19 @@ import { getMerchantByAccount, putMerchant } from "../shared/db.js";
  * Refresh Stripe OAuth access token using refresh token
  */
 export async function handler(event: any) {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
     return authResult;
   }
   const authContext = authResult;
-  
+
   if (!authContext.merchant_id) {
-    return bad('No Stripe account connected');
+    return bad('No Stripe account connected', { origin });
   }
   
   try {
@@ -23,7 +27,7 @@ export async function handler(event: any) {
     const merchant = await getMerchantByAccount(authContext.stripe_account_id!);
     
     if (!merchant.refresh_token) {
-      return bad('No refresh token available. Please reconnect your Stripe account.');
+      return bad('No refresh token available. Please reconnect your Stripe account.', { origin });
     }
     
     // Refresh the token
@@ -43,7 +47,7 @@ export async function handler(event: any) {
     
     if (!json.access_token) {
       console.error('Token refresh failed:', json);
-      return bad('Failed to refresh token: ' + (json.error_description || json.error));
+      return bad('Failed to refresh token: ' + (json.error_description || json.error), { origin });
     }
     
     // Save new tokens
@@ -57,10 +61,10 @@ export async function handler(event: any) {
     return ok({
       message: 'Token refreshed successfully',
       expires_in: json.expires_in || 3600
-    });
-    
+    }, { origin });
+
   } catch (error: any) {
     console.error('Token refresh error:', error);
-    return bad('Failed to refresh token: ' + error.message);
+    return bad('Failed to refresh token: ' + error.message, { origin });
   }
 }

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -1,4 +1,4 @@
-import { ok, bad, createErrorResponse } from "../shared/responses.js";
+import { ok, bad, createErrorResponse, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
@@ -8,6 +8,10 @@ const sfn = new SFNClient({});
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -17,13 +21,13 @@ export async function handler(event: any) {
   
   const disputeId = event.pathParameters?.id;
   if (!disputeId) {
-    return bad("Missing dispute ID");
+    return bad("Missing dispute ID", { origin });
   }
   
   // Get merchant ID from auth context or query params
   const merchantId = authContext.merchant_id || event.queryStringParameters?.merchant;
   if (!merchantId) {
-    return bad("No merchant account connected");
+    return bad("No merchant account connected", { origin });
   }
   
   // VERIFY USER OWNS THIS MERCHANT ACCOUNT
@@ -31,7 +35,7 @@ export async function handler(event: any) {
   if (!hasAccess) {
     return createErrorResponse(403, 'Access denied', {
       error: 'You do not have access to this merchant account'
-    });
+    }, { origin });
   }
   
   try {
@@ -40,7 +44,7 @@ export async function handler(event: any) {
     if (!caseData) {
       return createErrorResponse(404, 'Not found', {
         error: 'Dispute not found'
-      });
+      }, { origin });
     }
     
     // Check if dispute is in a retryable state
@@ -49,7 +53,7 @@ export async function handler(event: any) {
       return createErrorResponse(400, 'Invalid state', {
         error: `Cannot retry dispute in status: ${caseData.status}`,
         allowedStatuses: retryableStatuses
-      });
+      }, { origin });
     }
     
     // Get fresh dispute data from Stripe
@@ -67,7 +71,7 @@ export async function handler(event: any) {
         return createErrorResponse(400, 'Deadline passed', {
           error: 'Evidence submission deadline has passed',
           deadline: deadline.toISOString()
-        });
+        }, { origin });
       }
     }
     
@@ -99,9 +103,9 @@ export async function handler(event: any) {
         dispute_id: disputeId,
         execution_name: executionName,
         status: caseData.status,
-        deadline: dispute.evidence_details?.due_by ? 
+        deadline: dispute.evidence_details?.due_by ?
           new Date(dispute.evidence_details.due_by * 1000).toISOString() : null
-      });
+      }, { origin });
     } else {
       // Fallback: Direct evidence collection and submission
       console.log('No Step Functions configured, attempting direct retry');
@@ -194,33 +198,33 @@ export async function handler(event: any) {
             evidence_submitted: true,
             submission_result: submitResult,
             workflow: 'direct'
-          });
+          }, { origin });
         } else {
           return ok({
             message: 'Evidence staged but not submitted (manual review required)',
             dispute_id: disputeId,
             evidence_staged: true,
             workflow: 'direct'
-          });
+          }, { origin });
         }
-        
+
       } catch (directRetryError: any) {
         console.error('Direct retry failed:', directRetryError);
-        
+
         return createErrorResponse(500, 'Direct retry failed', {
           error: 'Failed to retry dispute processing',
           details: directRetryError.message,
           dispute_id: disputeId,
           workflow: 'direct'
-        });
+        }, { origin });
       }
     }
-    
+
   } catch (error: any) {
     console.error('Error retrying dispute:', error);
     return createErrorResponse(500, 'Internal error', {
       error: 'Failed to retry dispute',
       details: error.message
-    });
+    }, { origin });
   }
 }

--- a/src/handlers/statsHandler.ts
+++ b/src/handlers/statsHandler.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
 import Redis from 'ioredis';
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from '../shared/responses.js';
 
 const dynamodb = new DynamoDBClient({ region: 'us-east-1' });
 const CASES_TABLE = process.env.CASES_TABLE || 'chargeback-autopilot-stripe-prod-CasesTable-1LPIUKCN82FYI';
@@ -22,14 +23,12 @@ interface StatsResponse {
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
-  
-  // CORS headers
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
-    'Access-Control-Allow-Methods': 'GET,OPTIONS'
-  };
+  const origin = getRequestOrigin(event);
+
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) {
+    return preflight;
+  }
 
   try {
     // Try Redis cache first
@@ -154,15 +153,11 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const processingTime = Date.now() - startTime;
     console.log(`Stats endpoint processed in ${processingTime}ms`);
     
-    return {
-      statusCode: 200,
-      headers,
-      body: JSON.stringify({
-        success: true,
-        data: stats,
-        processingTime: `${processingTime}ms`
-      })
-    };
+    return jsonResponse(200, {
+      success: true,
+      data: stats,
+      processingTime: `${processingTime}ms`
+    }, { origin });
     
   } catch (error) {
     console.error('Error in stats handler:', error);
@@ -182,15 +177,11 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       dataSource: 'database'
     };
     
-    return {
-      statusCode: 200,
-      headers,
-      body: JSON.stringify({
-        success: true,
-        data: defaultStats,
-        processingTime: `${Date.now() - startTime}ms`,
-        note: 'Using default metrics due to temporary issue'
-      })
-    };
+    return jsonResponse(200, {
+      success: true,
+      data: defaultStats,
+      processingTime: `${Date.now() - startTime}ms`,
+      note: 'Using default metrics due to temporary issue'
+    }, { origin });
   }
 };

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -1,4 +1,4 @@
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, createErrorResponse, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import Stripe from 'stripe';
@@ -42,6 +42,10 @@ async function publishMetric(name: string, value: number, unit: string = 'Count'
 }
 
 export async function handler(event:any){
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -54,7 +58,7 @@ export async function handler(event:any){
   const merchantId = qs.merchant || authContext.merchant_id;
   const forceSubmit = qs.force === 'true'; // Allow forcing immediate submission
   
-  if(!merchantId || !id) return bad("missing merchant or id");
+  if(!merchantId || !id) return bad("missing merchant or id", { origin });
   
   // VERIFY USER OWNS THIS MERCHANT ACCOUNT
   const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
@@ -68,10 +72,7 @@ export async function handler(event:any){
       success: false,
       errorMessage: 'Attempted to submit evidence for unauthorized merchant'
     });
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
+    return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
   }
 
   try {
@@ -161,7 +162,7 @@ export async function handler(event:any){
               message: `Dispute skipped due to low win probability (${(winPrediction.score * 100).toFixed(1)}%). Threshold: ${(Number(process.env.MIN_WIN_THRESHOLD || '0.45') * 100).toFixed(0)}%`
             },
             dispute
-          });
+          }, { origin });
         }
       } catch (error) {
         console.error('[AI] Win prediction failed:', error);
@@ -210,7 +211,7 @@ export async function handler(event:any){
               confidence: timingRecommendation.confidence
             },
             dispute
-          });
+          }, { origin });
         }
       } catch (error) {
         console.error('[AI] Timing optimization failed:', error);
@@ -262,10 +263,10 @@ export async function handler(event:any){
       };
     }
     
-    return ok(submissionData);
-    
+    return ok(submissionData, { origin });
+
   } catch (error: any) {
     console.error('Error submitting dispute:', error);
-    return bad(`Failed to submit dispute: ${error.message}`);
+    return bad(`Failed to submit dispute: ${error.message}`, { origin });
   }
 }

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -1,4 +1,4 @@
-import { ok, bad } from "../shared/responses.js";
+import { ok, bad, createErrorResponse, getRequestOrigin, handleCorsPreflight } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
@@ -214,6 +214,10 @@ async function deactivatePremiumFeatures(merchantId: string) {
 
 // API endpoint to get subscription status
 export async function getSubscriptionStatus(event: any) {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'GET,OPTIONS');
+  if (preflight) return preflight;
+
   // Require authentication
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -224,16 +228,13 @@ export async function getSubscriptionStatus(event: any) {
   const merchantId = event.queryStringParameters?.merchant || authContext.merchant_id;
   
   if (!merchantId) {
-    return bad("No merchant account specified");
+    return bad("No merchant account specified", { origin });
   }
   
   // Verify ownership
   const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
   if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
+    return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
   }
   
   try {
@@ -280,16 +281,20 @@ export async function getSubscriptionStatus(event: any) {
           canceled_at: stripeSubscription.canceled_at
         } : null
       }
-    });
-    
+    }, { origin });
+
   } catch (error: any) {
     console.error('Error getting subscription status:', error);
-    return bad(`Failed to get subscription status: ${error.message}`);
+    return bad(`Failed to get subscription status: ${error.message}`, { origin });
   }
 }
 
 // API endpoint to cancel subscription
 export async function cancelSubscription(event: any) {
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
   // Require authentication
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -300,16 +305,13 @@ export async function cancelSubscription(event: any) {
   const merchantId = event.queryStringParameters?.merchant || authContext.merchant_id;
   
   if (!merchantId) {
-    return bad("No merchant account specified");
+    return bad("No merchant account specified", { origin });
   }
   
   // Verify ownership
   const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
   if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
+    return createErrorResponse(403, 'Access denied to this merchant account', undefined, { origin });
   }
   
   try {
@@ -317,7 +319,7 @@ export async function cancelSubscription(event: any) {
     const merchant = await getCase(merchantId, 'MERCHANT');
     
     if (!merchant?.subscription_id) {
-      return bad("No active subscription found");
+      return bad("No active subscription found", { origin });
     }
     
     // Cancel subscription at period end
@@ -356,10 +358,10 @@ export async function cancelSubscription(event: any) {
         cancel_at_period_end: canceledSubscription.cancel_at_period_end,
         current_period_end: (canceledSubscription as any).current_period_end
       }
-    });
-    
+    }, { origin });
+
   } catch (error: any) {
     console.error('Error canceling subscription:', error);
-    return bad(`Failed to cancel subscription: ${error.message}`);
+    return bad(`Failed to cancel subscription: ${error.message}`, { origin });
   }
 }

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -5,6 +5,7 @@ import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
 import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { getRequestOrigin, handleCorsPreflight, jsonResponse } from "../shared/responses.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -109,6 +110,13 @@ async function markEventProcessed(eventId: string, eventType: string): Promise<v
 }
 
 export async function handler(event:any){
+  const origin = getRequestOrigin(event);
+  const preflight = handleCorsPreflight(event, 'POST,OPTIONS');
+  if (preflight) return preflight;
+
+  const respond = (statusCode: number, payload: any) =>
+    jsonResponse(statusCode, typeof payload === 'string' ? { message: payload } : payload, { origin });
+
   const sig = event.headers['stripe-signature'] || event.headers['Stripe-Signature'];
   const rawBody = event.body;
   const account = (event.headers['stripe-account'] || event.headers['Stripe-Account']) as string | undefined;
@@ -128,13 +136,13 @@ export async function handler(event:any){
     evt = stripe.webhooks.constructEvent(rawBody, sig!, webhookSecret);
   }catch(e:any){
     console.error(`Webhook signature verification failed for account ${account}:`, e.message);
-    return { statusCode:400, body:`bad sig: ${e.message}` };
+    return respond(400, { error: 'Invalid signature', message: e.message });
   }
 
   // Check idempotency - prevent duplicate processing
   if (await WebhookIdempotencyService.isDuplicate(evt.id)) {
     console.log(`Event ${evt.id} already processed, skipping`);
-    return { statusCode: 200, body: 'duplicate event ignored' };
+    return respond(200, 'duplicate event ignored');
   }
 
   // Extract account from event if not in headers
@@ -168,7 +176,7 @@ export async function handler(event:any){
     }
     
     await WebhookIdempotencyService.markProcessed(evt.id, { type: evt.type });
-    return { statusCode: 200, body: 'subscription processed' };
+    return respond(200, 'subscription processed');
   }
   
   // Handle subscription updates with complete state management
@@ -182,7 +190,7 @@ export async function handler(event:any){
       if(!firebase_uid){
         console.warn('Subscription event without firebase_uid:', subscription.id);
         await WebhookIdempotencyService.markProcessed(evt.id, { type: evt.type });
-        return { statusCode: 200, body: 'subscription ignored - no user link' };
+        return respond(200, 'subscription ignored - no user link');
       }
       
       // Determine the action based on event type
@@ -280,7 +288,7 @@ export async function handler(event:any){
     }
     
     await WebhookIdempotencyService.markProcessed(evt.id, { type: evt.type });
-    return { statusCode: 200, body: `subscription ${evt.type} processed` };
+    return respond(200, `subscription ${evt.type} processed`);
   }
   
   // Handle invoice payment failures
@@ -299,7 +307,7 @@ export async function handler(event:any){
     }
     
     await WebhookIdempotencyService.markProcessed(evt.id, { type: evt.type });
-    return { statusCode: 200, body: 'payment failure processed' };
+    return respond(200, 'payment failure processed');
   }
 
   if(evt.type === 'charge.dispute.created' || evt.type === 'charge.dispute.updated'){
@@ -503,5 +511,5 @@ export async function handler(event:any){
   }
 
   await markEventProcessed(evt.id, evt.type);
-  return { statusCode:200, body:'ok' };
+  return respond(200, 'ok');
 }

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "./ddb.js";
+import { createErrorResponse, getRequestOrigin } from "./responses.js";
 
 // Initialize Firebase Admin SDK
 let firebaseApp: admin.app.App | null = null;
@@ -87,17 +88,14 @@ export async function validateAuth(authHeader: string | undefined): Promise<Auth
 /**
  * Middleware to require authentication
  */
-export async function requireAuth(event: any): Promise<AuthContext | { statusCode: number; body: string }> {
+export async function requireAuth(event: any): Promise<AuthContext | { statusCode: number; headers: Record<string, string>; body: string }> {
   const authHeader = event.headers?.Authorization || event.headers?.authorization;
   const authContext = await validateAuth(authHeader);
-  
+
   if (!authContext) {
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ error: 'Unauthorized' })
-    };
+    return createErrorResponse(401, 'Unauthorized', undefined, { origin: getRequestOrigin(event) });
   }
-  
+
   return authContext;
 }
 

--- a/src/shared/responses.ts
+++ b/src/shared/responses.ts
@@ -1,43 +1,147 @@
-// Complete set of security headers
-const securityHeaders = {
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Authorization,Content-Type,X-Requested-With,X-Request-ID',
-  'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
-  'Access-Control-Allow-Credentials': 'true',
-  // Security headers
-  'X-Content-Type-Options': 'nosniff',
-  'X-Frame-Options': 'DENY',
-  'X-XSS-Protection': '1; mode=block',
-  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
-  'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.stripe.com https://*.firebaseio.com",
-  'Referrer-Policy': 'strict-origin-when-cross-origin',
-  'Permissions-Policy': 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=*, usb=()'
+const DEFAULT_ALLOWED_METHODS = 'GET,POST,PUT,PATCH,DELETE,OPTIONS';
+const DEFAULT_ALLOWED_HEADERS = 'Authorization,Content-Type,X-Requested-With,X-Request-ID';
+
+const configuredOrigins = (process.env.ALLOWED_ORIGINS || '*')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+const allowAnyOrigin = configuredOrigins.includes('*');
+
+const resolveAllowedOrigin = (requestOrigin?: string | null) => {
+  if (allowAnyOrigin) {
+    return '*';
+  }
+
+  if (requestOrigin && configuredOrigins.includes(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  // Fall back to the first configured origin or wildcard if nothing provided
+  return configuredOrigins[0] || '*';
 };
 
-export const ok = (body:any) => ({
-  statusCode: 200,
-  headers: securityHeaders,
-  body: JSON.stringify(body)
-});
+export const getRequestOrigin = (event?: { headers?: Record<string, string | undefined> } | null) => {
+  if (!event?.headers) return null;
+  const headers = event.headers;
+  return (
+    headers.origin ||
+    headers.Origin ||
+    headers['x-forwarded-origin'] ||
+    headers['X-Forwarded-Origin'] ||
+    null
+  );
+};
 
-export const created = (body:any) => ({
-  statusCode: 201,
-  headers: securityHeaders,
-  body: JSON.stringify(body)
-});
+export const withSecurityHeaders = (
+  extraHeaders: Record<string, string> = {},
+  requestOrigin?: string | null
+) => {
+  const allowedOrigin = resolveAllowedOrigin(requestOrigin);
 
-export const bad = (msg:string) => ({
-  statusCode: 400,
-  headers: securityHeaders,
-  body: JSON.stringify({ error: msg })
-});
+  const baseHeaders: Record<string, string> = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Headers': process.env.ALLOWED_HEADERS || DEFAULT_ALLOWED_HEADERS,
+    'Access-Control-Allow-Methods': process.env.ALLOWED_METHODS || DEFAULT_ALLOWED_METHODS,
+    'Access-Control-Allow-Credentials': allowedOrigin === '*' ? 'false' : 'true',
+    'Access-Control-Max-Age': '600',
+    'Vary': 'Origin',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    'X-XSS-Protection': '1; mode=block',
+    'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+    'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.stripe.com https://*.firebaseio.com",
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
+    'X-DNS-Prefetch-Control': 'off'
+  };
 
-export const createErrorResponse = (statusCode: number, message: string, details?: any) => ({
+  return {
+    ...baseHeaders,
+    ...extraHeaders
+  };
+};
+
+export interface ResponseOptions {
+  headers?: Record<string, string>;
+  origin?: string | null;
+  rawBody?: boolean;
+}
+
+const buildBody = (body: any, rawBody?: boolean) => {
+  if (rawBody) {
+    return typeof body === 'string' ? body : '';
+  }
+  return JSON.stringify(body);
+};
+
+export const jsonResponse = (statusCode: number, body: any, options: ResponseOptions = {}) => ({
   statusCode,
-  headers: securityHeaders,
-  body: JSON.stringify({ 
-    error: message,
-    ...details 
-  })
+  headers: withSecurityHeaders(options.headers || {}, options.origin),
+  body: buildBody(body, options.rawBody)
 });
+
+export const ok = (body: any, options?: ResponseOptions) => jsonResponse(200, body, options);
+
+export const created = (body: any, options?: ResponseOptions) => jsonResponse(201, body, options);
+
+export const bad = (msg: string, options?: ResponseOptions) =>
+  jsonResponse(400, { error: msg }, options);
+
+export const createErrorResponse = (
+  statusCode: number,
+  message: string,
+  details?: any,
+  options?: ResponseOptions
+) => jsonResponse(statusCode, { error: message, ...details }, options);
+
+export const noContent = (options?: ResponseOptions & { statusCode?: number }) => ({
+  statusCode: options?.statusCode ?? 204,
+  headers: withSecurityHeaders(options?.headers || {}, options?.origin),
+  body: ''
+});
+
+export const redirect = (
+  location: string,
+  statusCode = 302,
+  options?: ResponseOptions
+) => jsonResponse(
+  statusCode,
+  '',
+  {
+    ...options,
+    rawBody: true,
+    headers: {
+      'Location': location,
+      'Content-Type': 'text/plain; charset=utf-8',
+      ...(options?.headers || {})
+    }
+  }
+);
+
+export const handleCorsPreflight = (
+  event: { httpMethod?: string | null; requestContext?: any; headers?: Record<string, string | undefined> | undefined } | null | undefined,
+  allowedMethods: string = DEFAULT_ALLOWED_METHODS
+) => {
+  const method =
+    event?.httpMethod ||
+    event?.requestContext?.http?.method ||
+    event?.requestContext?.httpMethod ||
+    '';
+
+  if (method.toUpperCase() !== 'OPTIONS') {
+    return null;
+  }
+
+  const origin = getRequestOrigin(event);
+  return noContent({
+    headers: {
+      'Access-Control-Allow-Methods': allowedMethods,
+      'Content-Type': 'text/plain; charset=utf-8'
+    },
+    origin
+  });
+};
+
+export const securityHeaders = withSecurityHeaders();


### PR DESCRIPTION
## Summary
- add a centralized response utility that applies stricter security headers and configurable CORS handling
- update HTTP-facing Lambda handlers to handle OPTIONS preflights, propagate the request origin, and reuse the shared helpers
- refresh webhook responses to emit JSON payloads with the standard security headers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deeee879b8832f8ae6fb0239e563c1