### PR TITLE
Add automated backup and disaster recovery automation

### DIFF
--- a/.github/workflows/nightly-backup.yml
+++ b/.github/workflows/nightly-backup.yml
@@ -1,0 +1,31 @@
+name: Nightly AWS Backups
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-backups:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AWS_REGION: us-east-1
+      STAGE: prod
+      STACK_NAME: chargeback-autopilot-stripe-prod
+      SSM_PARAMETER_PATH: /chargeback/prod
+      BACKUP_BUCKET: ${{ secrets.AWS_BACKUP_BUCKET }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_BACKUP_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_BACKUP_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run automated backup workflow
+        run: ./scripts/automated-backup.sh

--- a/docs/guides/BACKUP_AND_DR_RUNBOOK.md
+++ b/docs/guides/BACKUP_AND_DR_RUNBOOK.md
@@ -1,0 +1,73 @@
+# 🛡️ Backup & Disaster Recovery Runbook
+
+This runbook defines the automated backup jobs and disaster recovery (DR) procedures for the StripedShield production stack. It covers all persistent data planes provisioned by the Serverless stack (`MerchantsTable`, `CasesTable`, `SubmissionsTable`, `EvidenceTable`, and the `EvidenceBucket` object store) and the associated configuration held in AWS Systems Manager Parameter Store.【F:serverless.yml†L620-L675】
+
+---
+
+## 🔁 Automated Backup Pipeline
+
+### 1. Nightly GitHub Action
+A GitHub Actions workflow (`.github/workflows/nightly-backup.yml`) runs every day at 06:00 UTC and can be triggered manually via **Run workflow**. It performs the following steps:
+
+1. Checks out this repository revision.
+2. Configures AWS credentials sourced from GitHub Secrets (`AWS_BACKUP_ACCESS_KEY_ID`, `AWS_BACKUP_SECRET_ACCESS_KEY`, and `AWS_BACKUP_BUCKET`).
+3. Executes `scripts/automated-backup.sh` with production stage variables (`STAGE=prod`, `STACK_NAME=chargeback-autopilot-stripe-prod`, `SSM_PARAMETER_PATH=/chargeback/prod`).【F:.github/workflows/nightly-backup.yml†L1-L29】
+
+> ✅ **Action required:** Populate the secrets above in the repository settings. Optionally replace the static credentials with an IAM role by swapping the credential configuration in the workflow for `role-to-assume`.
+
+### 2. `scripts/automated-backup.sh`
+The bash automation script performs a full snapshot of critical resources:
+
+- Discovers DynamoDB tables and S3 buckets from the CloudFormation stack and triggers DynamoDB `create-backup` for each table, writing structured metadata (table name, backup name, and ARN) to a manifest.【F:scripts/automated-backup.sh†L34-L74】【F:scripts/automated-backup.sh†L76-L105】
+- Mirrors each evidence S3 bucket into the central backup bucket under a timestamped prefix and records the sync paths in the manifest.【F:scripts/automated-backup.sh†L107-L119】
+- Exports decrypted Parameter Store values under `/chargeback/<stage>` and stores them in the backup bucket alongside the manifest for traceability.【F:scripts/automated-backup.sh†L121-L143】
+
+Backups are written to `s3://$BACKUP_BUCKET/{manifests|s3|ssm}/<stage>/<timestamp>.json`. A manifest upload completes the run and gives DR automation a single source of truth for the snapshot contents.【F:scripts/automated-backup.sh†L145-L152】
+
+### 3. Monitoring the Backups
+- GitHub Action logs surface command failures; configure branch protection to require the job for visibility.
+- S3 lifecycle policies on the backup bucket should enforce retention (e.g., 90 days) and Glacier archival for long-term storage.
+- Optionally create a CloudWatch EventBridge rule to invoke the script from a Lambda if you prefer AWS-native scheduling. The script only depends on IAM permissions and the environment variables defined above.
+
+---
+
+## 🚨 Disaster Recovery Procedures
+
+### 1. Preparation Checklist
+- Confirm access to the backup S3 bucket and ensure the manifest for the desired timestamp exists.
+- Decide on the restoration mode:
+  - `DYNAMO_RESTORE_MODE=clone` (default) creates `*-restore-<timestamp>` tables for validation before cutover.
+  - `DYNAMO_RESTORE_MODE=in-place` deletes the live tables before restoring. Use only during a controlled outage window.
+
+### 2. Automated Restore Script
+Run `scripts/disaster-recovery-restore.sh` from a workstation or automation host with AWS credentials that can administer DynamoDB, S3, and SSM.
+
+```bash
+export AWS_REGION=us-east-1
+export STAGE=prod
+export BACKUP_BUCKET=my-stripeshield-backups
+export RESTORE_TIMESTAMP=20250815T060000Z
+# Optional: export DYNAMO_RESTORE_MODE=in-place
+./scripts/disaster-recovery-restore.sh
+```
+
+The script performs the following actions:
+
+1. Downloads the matching manifest from S3 and enumerates DynamoDB, S3, and SSM artefacts.【F:scripts/disaster-recovery-restore.sh†L24-L49】
+2. Restores each DynamoDB backup to either cloned or in-place tables, waiting for completion before moving to the next item.【F:scripts/disaster-recovery-restore.sh†L51-L74】
+3. Syncs evidence buckets back from the backup bucket, ensuring all artefacts are available.【F:scripts/disaster-recovery-restore.sh†L76-L84】
+4. Replays Parameter Store configuration with secure overwrites for environment secrets.【F:scripts/disaster-recovery-restore.sh†L86-L103】
+
+### 3. Post-Restore Validation
+- Run API smoke tests (`test-all-endpoints.sh`) against the restored environment.
+- Verify DynamoDB table item counts and compare to manifest timestamps.
+- Confirm evidence files render in the dashboard and Parameter Store shows expected values.
+- Document the incident in the ops log and rotate any secrets exposed during the recovery.
+
+---
+
+## 📚 Change Management
+- Update this runbook whenever new persistent resources are added to `serverless.yml` so they are included in the automation.
+- Store runbook revisions in source control (this file) and review quarterly during DR tests.
+
+By combining scheduled automation with a repeatable restoration path, the team can recover core services from S3-stored snapshots within hours while preserving compliance and audit evidence.

--- a/scripts/automated-backup.sh
+++ b/scripts/automated-backup.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  local timestamp
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "[$timestamp] $*" >&2
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Environment variable '$name' must be set" >&2
+    exit 1
+  fi
+}
+
+require_env AWS_REGION
+require_env STAGE
+require_env BACKUP_BUCKET
+
+STACK_NAME="${STACK_NAME:-chargeback-autopilot-stripe-${STAGE}}"
+SSM_PARAMETER_PATH="${SSM_PARAMETER_PATH:-/chargeback/${STAGE}}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+MANIFEST_PATH="$WORKDIR/backup-manifest.json"
+SSM_EXPORT_PATH="$WORKDIR/ssm-parameters.json"
+export AWS_REGION
+
+format_json_array() {
+  local -n entries=$1
+  if ((${#entries[@]} == 0)); then
+    echo "[]"
+    return
+  fi
+  local IFS=,
+  echo "[${entries[*]}]"
+}
+
+log "Starting backup run for stage '$STAGE' (stack: $STACK_NAME)"
+
+log "Resolving CloudFormation resources"
+STACK_RESOURCES=$(aws cloudformation describe-stack-resources \
+  --stack-name "$STACK_NAME" \
+  --query "StackResources[].{Type:ResourceType,PhysicalId:PhysicalResourceId}" \
+  --output json)
+
+declare -a dynamo_tables=()
+mapfile -t dynamo_tables < <(python - "$STACK_RESOURCES" <<'PY'
+import json, sys
+resources = json.loads(sys.argv[1])
+for resource in resources:
+    if resource.get("Type") == "AWS::DynamoDB::Table":
+        print(resource["PhysicalId"])
+PY
+)
+
+declare -a s3_buckets=()
+mapfile -t s3_buckets < <(python - "$STACK_RESOURCES" <<'PY'
+import json, sys
+resources = json.loads(sys.argv[1])
+for resource in resources:
+    if resource.get("Type") == "AWS::S3::Bucket":
+        print(resource["PhysicalId"])
+PY
+)
+
+declare -a dynamo_manifest_entries=()
+for table in "${dynamo_tables[@]}"; do
+  if [[ -z "$table" ]]; then
+    continue
+  fi
+  backup_name="${table//:/-}-${TIMESTAMP}"
+  log "Creating DynamoDB backup for $table"
+  backup_output=$(aws dynamodb create-backup \
+    --table-name "$table" \
+    --backup-name "$backup_name" \
+    --output json)
+  backup_arn=$(python - <<'PY'
+import json, sys
+payload = json.load(sys.stdin)
+print(payload["BackupDetails"]["BackupArn"])
+PY
+<<<"$backup_output")
+  dynamo_manifest_entries+=("{\"table\":\"$table\",\"backupName\":\"$backup_name\",\"backupArn\":\"$backup_arn\"}")
+done
+
+declare -a s3_manifest_entries=()
+for bucket in "${s3_buckets[@]}"; do
+  if [[ -z "$bucket" ]]; then
+    continue
+  fi
+  destination="s3://${BACKUP_BUCKET}/s3/${bucket}/${TIMESTAMP}"
+  log "Syncing s3://$bucket to $destination"
+  aws s3 sync "s3://$bucket" "$destination" --only-show-errors
+  s3_manifest_entries+=("{\"source\":\"$bucket\",\"destination\":\"$destination\"}")
+done
+
+log "Exporting SSM parameters from $SSM_PARAMETER_PATH"
+aws ssm get-parameters-by-path \
+  --path "$SSM_PARAMETER_PATH" \
+  --with-decryption \
+  --recursive \
+  --output json > "$SSM_EXPORT_PATH"
+ssm_s3_object="s3://${BACKUP_BUCKET}/ssm/${STAGE}/${TIMESTAMP}.json"
+aws s3 cp "$SSM_EXPORT_PATH" "$ssm_s3_object" --only-show-errors
+
+log "Creating manifest"
+dynamo_json=$(format_json_array dynamo_manifest_entries)
+s3_json=$(format_json_array s3_manifest_entries)
+{
+  echo '{'
+  echo "  \"timestamp\": \"$TIMESTAMP\"," 
+  echo "  \"stage\": \"$STAGE\"," 
+  echo "  \"stackName\": \"$STACK_NAME\"," 
+  echo "  \"dynamodbBackups\": $dynamo_json,"
+  echo "  \"s3Syncs\": $s3_json,"
+  echo "  \"ssmParameterExport\": {\"path\": \"$SSM_PARAMETER_PATH\", \"s3Object\": \"$ssm_s3_object\"}"
+  echo '}'
+} > "$MANIFEST_PATH"
+
+manifest_s3_object="s3://${BACKUP_BUCKET}/manifests/${STAGE}/${TIMESTAMP}.json"
+aws s3 cp "$MANIFEST_PATH" "$manifest_s3_object" --only-show-errors
+
+log "Backup completed. Manifest uploaded to $manifest_s3_object"

--- a/scripts/disaster-recovery-restore.sh
+++ b/scripts/disaster-recovery-restore.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  local timestamp
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "[$timestamp] $*" >&2
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Environment variable '$name' must be set" >&2
+    exit 1
+  fi
+}
+
+require_env AWS_REGION
+require_env STAGE
+require_env BACKUP_BUCKET
+require_env RESTORE_TIMESTAMP
+
+STACK_NAME="${STACK_NAME:-chargeback-autopilot-stripe-${STAGE}}"
+DYNAMO_RESTORE_MODE="${DYNAMO_RESTORE_MODE:-clone}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+MANIFEST_PATH="$WORKDIR/manifest.json"
+export AWS_REGION
+
+manifest_s3_object="s3://${BACKUP_BUCKET}/manifests/${STAGE}/${RESTORE_TIMESTAMP}.json"
+log "Fetching manifest ${manifest_s3_object}"
+aws s3 cp "$manifest_s3_object" "$MANIFEST_PATH" --only-show-errors
+
+log "Parsing manifest"
+dynamo_entries=$(python - "$MANIFEST_PATH" <<'PY'
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+entries = manifest.get("dynamodbBackups", [])
+print("\n".join(f"{entry['table']} {entry['backupArn']}" for entry in entries))
+PY
+)
+
+s3_entries=$(python - "$MANIFEST_PATH" <<'PY'
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+entries = manifest.get("s3Syncs", [])
+print("\n".join(f"{entry['source']} {entry['destination']}" for entry in entries))
+PY
+)
+
+ssm_object=$(python - "$MANIFEST_PATH" <<'PY'
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+export = manifest.get("ssmParameterExport", {})
+print(export.get("s3Object", ""))
+PY
+)
+
+if [[ -n "$dynamo_entries" ]]; then
+  log "Restoring DynamoDB tables using mode '$DYNAMO_RESTORE_MODE'"
+  while read -r table backup_arn; do
+    [[ -z "$table" ]] && continue
+    if [[ "$DYNAMO_RESTORE_MODE" == "in-place" ]]; then
+      log "Deleting existing table $table"
+      aws dynamodb delete-table --table-name "$table" >/dev/null 2>&1 || true
+      aws dynamodb wait table-not-exists --table-name "$table" || true
+      target_table="$table"
+    else
+      target_table="${table}-restore-${RESTORE_TIMESTAMP}"
+    fi
+    log "Restoring backup $backup_arn to table $target_table"
+    aws dynamodb restore-table-from-backup \
+      --target-table-name "$target_table" \
+      --backup-arn "$backup_arn" >/dev/null
+    aws dynamodb wait table-exists --table-name "$target_table"
+  done <<< "$dynamo_entries"
+else
+  log "No DynamoDB backups found in manifest"
+fi
+
+if [[ -n "$s3_entries" ]]; then
+  log "Restoring S3 buckets"
+  while read -r source destination; do
+    [[ -z "$source" ]] && continue
+    backup_prefix="s3://${BACKUP_BUCKET}/s3/${source}/${RESTORE_TIMESTAMP}/"
+    log "Syncing $backup_prefix back to s3://$source"
+    aws s3 sync "$backup_prefix" "s3://$source" --only-show-errors
+  done <<< "$s3_entries"
+else
+  log "No S3 sync entries found in manifest"
+fi
+
+if [[ -n "$ssm_object" ]]; then
+  log "Restoring SSM parameters from $ssm_object"
+  ssm_file="$WORKDIR/ssm-parameters.json"
+  aws s3 cp "$ssm_object" "$ssm_file" --only-show-errors
+  python - "$ssm_file" <<'PY'
+import json, subprocess, sys
+payload = json.load(open(sys.argv[1]))
+for param in payload.get("Parameters", []):
+    name = param["Name"]
+    value = param.get("Value", "")
+    param_type = param.get("Type", "String")
+    key_id = param.get("KeyId")
+    cmd = ["aws", "ssm", "put-parameter", "--name", name, "--value", value, "--type", param_type, "--overwrite"]
+    if key_id:
+        cmd.extend(["--key-id", key_id])
+    subprocess.run(cmd, check=True)
+PY
+else
+  log "No SSM export found in manifest"
+fi
+
+log "Disaster recovery restore complete"


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow that runs the new backup automation for the production stack
- provide scripts for taking DynamoDB, S3, and SSM snapshots and restoring them from a manifest
- document the end-to-end backup and disaster recovery procedures in a dedicated runbook

## Testing
- bash -n scripts/automated-backup.sh
- bash -n scripts/disaster-recovery-restore.sh

------
https://chatgpt.com/codex/tasks/task_e_68deeebde948832fa45f498cfe89a264