### PR TITLE
Secure sensitive data with encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ OPENAI_API_KEY=sk-proj-***
 AI_MODEL=gpt-5
 AI_ENABLED=true
 REDIS_URL=redis://stripedshield-redis.mot6cw.0001.use1.cache.amazonaws.com:6379
+ENCRYPTION_KEY=$(openssl rand -base64 32)
 ```
+
+> **Security**: `ENCRYPTION_KEY` must decode to 32 bytes. Use a strong, randomly generated value (Base64 or hex). It is required to encrypt Stripe OAuth tokens and webhook secrets before they are stored.
 
 ## 📈 Performance Metrics
 

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,7 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { decryptSensitiveRecord } from "../shared/encryption.js";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -17,7 +18,7 @@ export async function handler(event: any) {
       FilterExpression: 'attribute_exists(access_token) AND attribute_exists(refresh_token)'
     }));
     
-    const merchants = scanResult.Items || [];
+    const merchants = (scanResult.Items || []).map(item => decryptSensitiveRecord(item));
     console.log(`Found ${merchants.length} merchants with OAuth tokens`);
     
     const results = {

--- a/src/handlers/buildEvidence.ts
+++ b/src/handlers/buildEvidence.ts
@@ -204,7 +204,7 @@ export async function handler(evt:any){
     // Apply ML optimizations if available
     if (mlOptimizedEvidence && fraudDetected) {
       console.log('🚨 ML: Fraud detected, adding extra verification evidence');
-      evidencePackage.fraudWarning = true;
+      (evidencePackage as Record<string, any>).fraudWarning = true;
     }
     
     // Extract the evidence object for Stripe submission

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,31 +1,47 @@
 import { ddb } from "./ddb.js";
 import { PutCommand, GetCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { encryptSensitiveRecord, decryptSensitiveRecord } from "./encryption.js";
 
 const MERCHANTS = process.env.MERCHANTS_TABLE!;
 const CASES = process.env.CASES_TABLE!;
 
+const MERCHANT_SENSITIVE_FIELDS = [
+  'access_token',
+  'refresh_token',
+  'webhook_secret',
+  'stripe_publishable_key'
+];
+
+const CASE_SENSITIVE_FIELDS = [
+  'merchant_access_token'
+];
+
 export async function putMerchant(m:any){
   // Use stripe_account_id as the primary key for consistency
   const merchant_id = m.stripe_account_id || m.merchant_id;
-  const item = {
+  const item = encryptSensitiveRecord({
     pk: `MERCHANT#${merchant_id}`,
     merchant_id: merchant_id,
     stripe_account_id: merchant_id, // Ensure both fields are set
     ...m,
     created_at: m.created_at || new Date().toISOString()
-  };
+  }, MERCHANT_SENSITIVE_FIELDS);
   await ddb.send(new PutCommand({ TableName: MERCHANTS, Item: item }));
 }
 
 export async function getMerchantByAccount(stripe_account_id:string){
   const pk = `MERCHANT#${stripe_account_id}`;
   const r = await ddb.send(new GetCommand({ TableName: MERCHANTS, Key: { pk } }));
-  return r.Item || { pk, merchant_id: stripe_account_id, stripe_account_id, settings: { autoSubmit: true, autoAcceptBelowCents: 0, retentionDays: 540, notifyEmails: [] } };
+  if (!r.Item) {
+    return { pk, merchant_id: stripe_account_id, stripe_account_id, settings: { autoSubmit: true, autoAcceptBelowCents: 0, retentionDays: 540, notifyEmails: [] } };
+  }
+
+  return decryptSensitiveRecord(r.Item, MERCHANT_SENSITIVE_FIELDS);
 }
 
 export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
   const now = Math.floor(Date.now()/1000);
-  const item = {
+  const item = encryptSensitiveRecord({
     pk: `MERCHANT#${merchantId}`,
     sk: `CASE#${dispute.id}`,
     dispute_id: dispute.id,
@@ -44,7 +60,7 @@ export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
     gsi2_pk: `STATUS#${dispute.status}`,
     gsi2_sk: dispute.evidence_details?.due_by || 0,
     ...extras
-  };
+  }, CASE_SENSITIVE_FIELDS);
   await ddb.send(new PutCommand({ TableName: CASES, Item: item }));
   return item;
 }
@@ -56,7 +72,7 @@ export async function listCases(merchantId:string, status?:string){
     KeyConditionExpression: "pk = :pk",
     ExpressionAttributeValues: { ":pk": pk }
   }));
-  let items = r.Items || [];
+  let items = (r.Items || []).map(item => decryptSensitiveRecord(item, CASE_SENSITIVE_FIELDS));
   if(status) items = items.filter(i => i.status === status);
   return items.sort((a,b) => (a.due_by_epoch||0)-(b.due_by_epoch||0));
 }
@@ -64,10 +80,10 @@ export async function listCases(merchantId:string, status?:string){
 export async function getCase(merchantId:string, disputeId:string){
   const pk = `MERCHANT#${merchantId}`, sk = `CASE#${disputeId}`;
   const r = await ddb.send(new GetCommand({ TableName: CASES, Key: { pk, sk } }));
-  return r.Item;
+  return r.Item ? decryptSensitiveRecord(r.Item, CASE_SENSITIVE_FIELDS) : undefined;
 }
 
 export async function scanMerchants(){
   const r = await ddb.send(new ScanCommand({ TableName: MERCHANTS }));
-  return r.Items || [];
+  return (r.Items || []).map(item => decryptSensitiveRecord(item, MERCHANT_SENSITIVE_FIELDS));
 }

--- a/src/shared/encryption.ts
+++ b/src/shared/encryption.ts
@@ -1,0 +1,100 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ENCRYPTION_PREFIX = 'enc:v1:';
+const DEFAULT_SENSITIVE_FIELDS = [
+  'access_token',
+  'refresh_token',
+  'webhook_secret',
+  'stripe_publishable_key',
+  'merchant_access_token'
+] as const;
+
+type SensitiveField = (typeof DEFAULT_SENSITIVE_FIELDS)[number] | string;
+
+function getKey(): Buffer {
+  const rawKey = process.env.ENCRYPTION_KEY?.trim();
+  if (!rawKey) {
+    throw new Error('ENCRYPTION_KEY environment variable is required for sensitive data encryption');
+  }
+
+  const base64Buffer = Buffer.from(rawKey, 'base64');
+  if (base64Buffer.length === 32) {
+    return base64Buffer;
+  }
+
+  const hexBuffer = Buffer.from(rawKey, 'hex');
+  if (hexBuffer.length === 32) {
+    return hexBuffer;
+  }
+
+  const utf8Buffer = Buffer.from(rawKey, 'utf8');
+  if (utf8Buffer.length === 32) {
+    return utf8Buffer;
+  }
+
+  throw new Error('ENCRYPTION_KEY must decode to 32 bytes for AES-256-GCM');
+}
+
+function encryptBuffer(value: string): { ciphertext: Buffer; iv: Buffer; authTag: Buffer } {
+  const key = getKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return { ciphertext, iv, authTag };
+}
+
+function decryptBuffer(iv: Buffer, authTag: Buffer, ciphertext: Buffer): Buffer {
+  const key = getKey();
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+export function isEncryptedValue(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith(ENCRYPTION_PREFIX);
+}
+
+export function encryptString(value: string): string {
+  if (isEncryptedValue(value)) {
+    return value;
+  }
+
+  const { ciphertext, iv, authTag } = encryptBuffer(value);
+  const payload = Buffer.concat([iv, authTag, ciphertext]);
+  return `${ENCRYPTION_PREFIX}${payload.toString('base64')}`;
+}
+
+export function decryptString(value: string): string {
+  if (!isEncryptedValue(value)) {
+    return value;
+  }
+
+  const payload = Buffer.from(value.substring(ENCRYPTION_PREFIX.length), 'base64');
+  const iv = payload.subarray(0, 12);
+  const authTag = payload.subarray(12, 28);
+  const ciphertext = payload.subarray(28);
+
+  const decrypted = decryptBuffer(iv, authTag, ciphertext);
+  return decrypted.toString('utf8');
+}
+
+export function encryptSensitiveRecord<T extends Record<string, any>>(record: T, fields: ReadonlyArray<SensitiveField> = DEFAULT_SENSITIVE_FIELDS): T {
+  const result: Record<string, any> = { ...record };
+  for (const field of fields) {
+    if (typeof result[field] === 'string') {
+      result[field] = encryptString(result[field]);
+    }
+  }
+  return result as T;
+}
+
+export function decryptSensitiveRecord<T extends Record<string, any>>(record: T, fields: ReadonlyArray<SensitiveField> = DEFAULT_SENSITIVE_FIELDS): T {
+  const result: Record<string, any> = { ...record };
+  for (const field of fields) {
+    if (typeof result[field] === 'string' && isEncryptedValue(result[field])) {
+      result[field] = decryptString(result[field]);
+    }
+  }
+  return result as T;
+}

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { decryptString, encryptString } from './encryption.js';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
@@ -24,7 +25,11 @@ export async function getMerchantWebhookSecret(merchantId: string): Promise<stri
     
     if (result.Item?.webhook_secret) {
       console.log(`[WEBHOOK] Using merchant-specific webhook secret for ${merchantId}`);
-      return result.Item.webhook_secret;
+      const storedSecret = result.Item.webhook_secret;
+      if (typeof storedSecret === 'string') {
+        return decryptString(storedSecret);
+      }
+      console.warn('[WEBHOOK] Webhook secret is not a string, ignoring merchant-specific value');
     }
     
     // If no merchant-specific secret, check for endpoint ID and construct
@@ -120,6 +125,8 @@ export async function storeWebhookSecret(
   const { UpdateCommand } = await import('@aws-sdk/lib-dynamodb');
   
   try {
+    const encryptedSecret = encryptString(webhookSecret);
+
     await ddb.send(new UpdateCommand({
       TableName: MERCHANTS_TABLE,
       Key: {
@@ -127,7 +134,7 @@ export async function storeWebhookSecret(
       },
       UpdateExpression: 'SET webhook_secret = :secret, webhook_endpoint_id = :endpoint, webhook_secret_updated = :now',
       ExpressionAttributeValues: {
-        ':secret': webhookSecret,
+        ':secret': encryptedSecret,
         ':endpoint': webhookEndpointId || null,
         ':now': new Date().toISOString()
       }


### PR DESCRIPTION
## Summary
- add an AES-256-GCM encryption helper and use it when persisting sensitive merchant and case fields
- encrypt stored webhook secrets and decrypt them transparently for signature validation
- decrypt OAuth records before refreshing tokens and document the required ENCRYPTION_KEY runtime setting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deee3d8ad0832faaff7ea3788c75d4