### PR TITLE
Add request and response validation middleware for API handlers

### DIFF
--- a/src/handlers/authLoginHandler.ts
+++ b/src/handlers/authLoginHandler.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import jwt from 'jsonwebtoken';
-import crypto from 'crypto';
+import { z } from 'zod';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const JWT_SECRET = process.env.JWT_SECRET || 'stripedshield-demo-secret-2025';
 const JWT_EXPIRY = '7d'; // 7 days validity
@@ -41,9 +42,26 @@ const DEMO_USERS = [
   }
 ];
 
-export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  const startTime = Date.now();
-  
+const loginRequestSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1).max(128).optional()
+});
+
+const loginResponseSchema = z.object({
+  success: z.boolean(),
+  token: z.string().optional(),
+  user: z.object({
+    email: z.string().email(),
+    merchantId: z.string(),
+    role: z.string(),
+    name: z.string()
+  }).optional(),
+  expiresIn: z.string().optional(),
+  error: z.string().optional()
+}).passthrough();
+
+export const handler = withRequestResponseValidation(
+async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   // CORS headers
   const headers = {
     'Content-Type': 'application/json',
@@ -62,12 +80,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   try {
-    // Parse request body
-    let loginRequest: LoginRequest;
-    
-    try {
-      loginRequest = JSON.parse(event.body || '{}');
-    } catch (error) {
+    const loginRequest = (event as typeof event & { validatedBody?: LoginRequest }).validatedBody;
+    if (!loginRequest) {
       return {
         statusCode: 400,
         headers,
@@ -78,27 +92,15 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       };
     }
 
-    // Validate email
-    if (!loginRequest.email) {
-      return {
-        statusCode: 400,
-        headers,
-        body: JSON.stringify({
-          success: false,
-          error: 'Email is required'
-        })
-      };
-    }
-
     // Normalize email
     const email = loginRequest.email.toLowerCase().trim();
-    
+
     // Check for demo users
     const demoUser = DEMO_USERS.find(u => u.email === email);
-    
+
     // For demo purposes, allow access with just email for demo@stripedshield.com
     // In production, always require password
-    if (email === 'demo@stripedshield.com') {
+    if (email === 'demo@stripedshield.com' && demoUser) {
       // Generate JWT token
       const token = jwt.sign(
         {
@@ -198,7 +200,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   } catch (error) {
     console.error('Error in auth login handler:', error);
-    
+
     return {
       statusCode: 500,
       headers,
@@ -208,4 +210,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       })
     };
   }
-};
+}, {
+  bodySchema: loginRequestSchema,
+  responseSchema: loginResponseSchema
+});

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,12 +1,19 @@
+import { z } from 'zod';
 import { putMerchant } from "../shared/db.js";
 import Stripe from 'stripe';
-import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { createAuditLog, AuditAction } from "../shared/auditLog.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
-export async function handler(event:any){
-  const qs = event.queryStringParameters || {};
+const querySchema = z.object({
+  code: z.string().min(1, 'code is required'),
+  state: z.string().optional()
+});
+
+export const handler = withRequestResponseValidation(async (event:any) => {
+  const qs = event.validatedQuery || event.queryStringParameters || {};
   const code = qs.code;
   const state = qs.state; // Should contain firebase_uid
-  
+
   if(!code) return { statusCode:400, body:'missing code' };
 
   const body = new URLSearchParams({
@@ -102,4 +109,4 @@ export async function handler(event:any){
   // Redirect to frontend connect page with success
   const frontendCallbackUrl = `https://stripedshield-founders-1755231149.netlify.app/connect.html?success=true&stripe_account_id=${merchant_id}${firebase_uid ? '&uid=' + firebase_uid : ''}`;
   return { statusCode: 302, headers: { Location: frontendCallbackUrl }, body: '' };
-}
+}, { querySchema });

--- a/src/handlers/authStripeStart.ts
+++ b/src/handlers/authStripeStart.ts
@@ -1,14 +1,22 @@
 import crypto from 'crypto';
-import { ok, bad } from "../shared/responses.js";
+import { z } from 'zod';
+import { bad } from "../shared/responses.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const STRIPE_CLIENT_ID = process.env.STRIPE_CLIENT_ID!;
 const STRIPE_REDIRECT_URI = process.env.STRIPE_REDIRECT_URI!;
 
-export async function handler(event: any){
+const querySchema = z.object({
+  uid: z.string().trim().min(1).optional(),
+  firebase_uid: z.string().trim().min(1).optional()
+});
+
+export const handler = withRequestResponseValidation(
+async (event: any) => {
   if(!STRIPE_CLIENT_ID || !STRIPE_REDIRECT_URI) return bad("Stripe not configured");
-  
+
   // Get Firebase UID from query parameters to link accounts
-  const qs = event.queryStringParameters || {};
+  const qs = event.validatedQuery || event.queryStringParameters || {};
   const firebase_uid = qs.uid || qs.firebase_uid || null;
   
   // Create state with Firebase UID and CSRF token
@@ -38,4 +46,4 @@ export async function handler(event: any){
     },
     body: ''
   };
-}
+}, { querySchema });

--- a/src/handlers/buildEvidence.ts
+++ b/src/handlers/buildEvidence.ts
@@ -137,10 +137,10 @@ export async function handler(evt:any){
   try {
     // Use the advanced evidence bundler for CE3.0 and reason-specific evidence
     const evidencePackage = await bundler.assembleEvidencePackage(
-      dispute, 
+      dispute,
       merchant?.id || 'default',
       merchant?.stripeAccountId
-    );
+    ) as any;
     
     // ML Score Cache Integration (Safe - with fallback)
     let mlOptimizedEvidence: any = null;

--- a/src/handlers/collectCase.ts
+++ b/src/handlers/collectCase.ts
@@ -1,11 +1,11 @@
 import { bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
-import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { StartExecutionCommand, SFNClient as StepFunctionsClient } from "@aws-sdk/client-sfn";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const sfn = new StepFunctionsClient({});
 
-export async function handler(event:any){
+export const handler = withRequestResponseValidation(async (event:any) => {
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -34,4 +34,4 @@ export async function handler(event:any){
   }));
 
   return { statusCode:202, body:'started' };
-}
+});

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -1,10 +1,18 @@
 import Stripe from 'stripe';
+import { z } from 'zod';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
-export async function handler(event: any) {
+const checkoutRequestSchema = z.object({
+  email: z.string().email().optional(),
+  price_id: z.string().min(1).optional()
+});
+
+export const handler = withRequestResponseValidation<z.infer<typeof checkoutRequestSchema>>(
+async (event: any) => {
   // Get auth context if user is logged in (optional for checkout)
   let authContext = null;
   try {
@@ -15,22 +23,22 @@ export async function handler(event: any) {
   } catch (e) {
     // User not logged in, that's okay for checkout
   }
-  
-  const body = JSON.parse(event.body || '{}');
+
+  const body = (event as typeof event & { validatedBody?: z.infer<typeof checkoutRequestSchema> }).validatedBody || {};
   const email = body.email || authContext?.email;
   const priceId = body.price_id || process.env.STRIPE_PRICE_ID || 'price_1QWtQxDOwkStzJVXK8PqXJ0z'; // Default founder price
-  
+
   if (!email) {
     return bad('Email is required');
   }
-  
+
   try {
     // Create or retrieve customer
     const customers = await stripe.customers.list({
       email: email,
       limit: 1
     });
-    
+
     let customer;
     if (customers.data.length > 0) {
       customer = customers.data[0];
@@ -43,7 +51,7 @@ export async function handler(event: any) {
         }
       });
     }
-    
+
     // Create checkout session
     const session = await stripe.checkout.sessions.create({
       customer: customer.id,
@@ -68,14 +76,16 @@ export async function handler(event: any) {
         email: email
       }
     });
-    
-    return ok({ 
+
+    return ok({
       checkout_url: session.url,
       session_id: session.id
     });
-    
+
   } catch (error: any) {
     console.error('Checkout session error:', error);
     return bad(error.message);
   }
-}
+}, {
+  bodySchema: checkoutRequestSchema
+});

--- a/src/handlers/debugRedis.ts
+++ b/src/handlers/debugRedis.ts
@@ -1,11 +1,12 @@
 import Redis from 'ioredis';
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 /**
  * Debug endpoint to test Redis connectivity
  * Helps diagnose Redis connection issues
  */
-export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+export const handler = withRequestResponseValidation(async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
     const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
     
@@ -69,4 +70,4 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }, null, 2)
     };
   }
-};
+});

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -3,6 +3,7 @@ import { requireAuth, verifyMerchantOwnership } from '../shared/auth.js';
 import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
 import Stripe from 'stripe';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -29,7 +30,7 @@ interface Dispute {
 
 // Now using REAL Stripe data - no more mocks!
 
-export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+export const handler = withRequestResponseValidation(async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
   
   // CORS headers
@@ -168,4 +169,4 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       })
     };
   }
-};
+});

--- a/src/handlers/getCase.ts
+++ b/src/handlers/getCase.ts
@@ -2,8 +2,9 @@ import { ok, bad } from "../shared/responses.js";
 import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { validationMiddleware, commonSchemas } from "../shared/validation.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
-export async function handler(event:any){
+export const handler = withRequestResponseValidation(async (event:any) => {
   // Validate input first
   const validationSchema = {
     ...commonSchemas.disputeId,
@@ -44,4 +45,4 @@ export async function handler(event:any){
   
   const item = await getCase(merchantId, id);
   return ok({ item });
-}
+});

--- a/src/handlers/getUserDisputes.ts
+++ b/src/handlers/getUserDisputes.ts
@@ -1,12 +1,13 @@
 import { ok, bad } from "../shared/responses.js";
 import { listCases } from "../shared/db.js";
 import { requireAuth } from "../shared/auth.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 /**
  * Get disputes for the authenticated user only
  * No merchant parameter needed - uses user's own merchant account
  */
-export async function handler(event: any) {
+export const handler = withRequestResponseValidation(async (event: any) => {
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -64,4 +65,4 @@ export async function handler(event: any) {
     console.error('Error fetching user disputes:', error);
     return bad('Failed to fetch disputes: ' + error.message);
   }
-}
+});

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,17 +1,18 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { getRedisClient, isRedisReady } from "../cache/redisConnection";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const dynamo = new DynamoDBClient({});
 
 const withTimeout = <T>(p: Promise<T>, ms = 350) =>
   Promise.race([
-    p, 
+    p,
     new Promise<never>((_, rej) => setTimeout(() => rej(new Error("timeout")), ms))
   ]);
 
-export const handler = async (_evt: any, ctx: any) => {
-  if (ctx && typeof ctx === 'object') {
-    ctx.callbackWaitsForEmptyEventLoop = false;
+export const handler = withRequestResponseValidation(async (_evt: any, context: any) => {
+  if (context && typeof context === 'object') {
+    context.callbackWaitsForEmptyEventLoop = false;
   }
 
   const checks: any = { redis: {}, dynamo: {} };
@@ -67,4 +68,4 @@ export const handler = async (_evt: any, ctx: any) => {
       ts: new Date().toISOString() 
     })
   };
-};
+});

--- a/src/handlers/listCases.ts
+++ b/src/handlers/listCases.ts
@@ -3,6 +3,7 @@ import { listCases } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { rateLimitMiddleware } from "../shared/rateLimit.js";
 import { validationMiddleware, commonSchemas } from "../shared/validation.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 import Redis from "ioredis";
 
 // Initialize Redis with lazy connection
@@ -20,7 +21,7 @@ function getRedis() {
   return redis;
 }
 
-export async function handler(event:any){
+export const handler = withRequestResponseValidation(async (event:any) => {
   // Check rate limit first
   const rateLimitResult = await rateLimitMiddleware(event);
   if (rateLimitResult) {
@@ -109,4 +110,4 @@ export async function handler(event:any){
   }
   
   return ok(response);
-}
+});

--- a/src/handlers/metrics.ts
+++ b/src/handlers/metrics.ts
@@ -1,12 +1,13 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { getRedisClient } from '../cache/redisConnection';
 import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 /**
  * Metrics endpoint for StripedShield
  * Returns performance metrics and win rate statistics
  */
-export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+export const handler = withRequestResponseValidation(async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
   
   try {
@@ -156,7 +157,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     
   } catch (error: any) {
     console.error('Metrics error:', error);
-    
+
     // Return partial metrics with 200 status
     return {
       statusCode: 200,
@@ -178,4 +179,4 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       })
     };
   }
-};
+});

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -3,11 +3,12 @@ import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
 import Stripe from 'stripe';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const sfn = new SFNClient({});
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
-export async function handler(event: any) {
+export const handler = withRequestResponseValidation(async (event: any) => {
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -223,4 +224,4 @@ export async function handler(event: any) {
       details: error.message
     });
   }
-}
+});

--- a/src/handlers/statsHandler.ts
+++ b/src/handlers/statsHandler.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { DynamoDBClient, ScanCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
 import Redis from 'ioredis';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const dynamodb = new DynamoDBClient({ region: 'us-east-1' });
 const CASES_TABLE = process.env.CASES_TABLE || 'chargeback-autopilot-stripe-prod-CasesTable-1LPIUKCN82FYI';
@@ -20,7 +21,7 @@ interface StatsResponse {
   dataSource: 'cache' | 'database';
 }
 
-export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+export const handler = withRequestResponseValidation(async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
   
   // CORS headers
@@ -193,4 +194,4 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       })
     };
   }
-};
+});

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -2,6 +2,7 @@ import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import Stripe from 'stripe';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 import { 
   predictWinRate, 
   shouldSubmit,
@@ -41,7 +42,7 @@ async function publishMetric(name: string, value: number, unit: string = 'Count'
   }
 }
 
-export async function handler(event:any){
+export const handler = withRequestResponseValidation(async (event:any) => {
   // REQUIRE AUTHENTICATION
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -268,4 +269,4 @@ export async function handler(event:any){
     console.error('Error submitting dispute:', error);
     return bad(`Failed to submit dispute: ${error.message}`);
   }
-}
+});

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -3,6 +3,7 @@ import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
 import Stripe from 'stripe';
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -213,7 +214,7 @@ async function deactivatePremiumFeatures(merchantId: string) {
 }
 
 // API endpoint to get subscription status
-export async function getSubscriptionStatus(event: any) {
+export const getSubscriptionStatus = withRequestResponseValidation(async (event: any) => {
   // Require authentication
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -286,10 +287,10 @@ export async function getSubscriptionStatus(event: any) {
     console.error('Error getting subscription status:', error);
     return bad(`Failed to get subscription status: ${error.message}`);
   }
-}
+});
 
 // API endpoint to cancel subscription
-export async function cancelSubscription(event: any) {
+export const cancelSubscription = withRequestResponseValidation(async (event: any) => {
   // Require authentication
   const authResult = await requireAuth(event);
   if ('statusCode' in authResult) {
@@ -362,4 +363,4 @@ export async function cancelSubscription(event: any) {
     console.error('Error canceling subscription:', error);
     return bad(`Failed to cancel subscription: ${error.message}`);
   }
-}
+});

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -5,6 +5,7 @@ import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
 import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { withRequestResponseValidation } from "../shared/httpValidation.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -108,7 +109,7 @@ async function markEventProcessed(eventId: string, eventType: string): Promise<v
   }
 }
 
-export async function handler(event:any){
+export const handler = withRequestResponseValidation(async (event:any) => {
   const sig = event.headers['stripe-signature'] || event.headers['Stripe-Signature'];
   const rawBody = event.body;
   const account = (event.headers['stripe-account'] || event.headers['Stripe-Account']) as string | undefined;
@@ -504,4 +505,4 @@ export async function handler(event:any){
 
   await markEventProcessed(evt.id, evt.type);
   return { statusCode:200, body:'ok' };
-}
+});

--- a/src/shared/httpValidation.ts
+++ b/src/shared/httpValidation.ts
@@ -1,0 +1,198 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { z, ZodSchema } from 'zod';
+import { createErrorResponse } from './responses.js';
+
+export interface ValidationOptions<
+  Body = unknown,
+  Query = Record<string, string | undefined>,
+  Path = Record<string, string | undefined>,
+  Response = unknown
+> {
+  bodySchema?: ZodSchema<Body>;
+  querySchema?: ZodSchema<Query>;
+  pathSchema?: ZodSchema<Path>;
+  responseSchema?: ZodSchema<Response>;
+  parseJsonBody?: boolean;
+  ensureJsonResponse?: boolean;
+}
+
+type ValidatedEvent<Body, Query, Path> = APIGatewayProxyEvent & {
+  validatedBody?: Body;
+  validatedQuery?: Query;
+  validatedPath?: Path;
+};
+
+const baseEventSchema = z.object({
+  headers: z.record(z.string(), z.any()).optional().default({}),
+  body: z.string().optional().nullable(),
+  queryStringParameters: z.record(z.string(), z.string()).optional().nullable(),
+  pathParameters: z.record(z.string(), z.string()).optional().nullable(),
+  httpMethod: z.string().optional(),
+  isBase64Encoded: z.boolean().optional().default(false)
+}).passthrough();
+
+const baseResponseSchema = z.object({
+  statusCode: z.number(),
+  headers: z.record(z.string(), z.any()).optional(),
+  body: z.string().optional().default(''),
+  isBase64Encoded: z.boolean().optional()
+}).passthrough();
+
+function decodeBody(event: APIGatewayProxyEvent): string | null {
+  if (!event.body) {
+    return null;
+  }
+
+  if (event.isBase64Encoded) {
+    try {
+      return Buffer.from(event.body, 'base64').toString('utf-8');
+    } catch (error) {
+      console.error('Failed to decode base64 body', error);
+      throw new Error('INVALID_BASE64_BODY');
+    }
+  }
+
+  return event.body;
+}
+
+export function withRequestResponseValidation<
+  Body = unknown,
+  Query = Record<string, string | undefined>,
+  Path = Record<string, string | undefined>,
+  Response = unknown
+>(
+  handler: (
+    event: ValidatedEvent<Body, Query, Path>,
+    context: Context
+  ) => Promise<APIGatewayProxyResult>,
+  options: ValidationOptions<Body, Query, Path, Response> = {}
+) {
+  return async (
+    event: APIGatewayProxyEvent,
+    context: Context
+  ): Promise<APIGatewayProxyResult> => {
+    const parsedEvent = baseEventSchema.safeParse(event);
+    if (!parsedEvent.success) {
+      console.warn('Request structure validation failed', parsedEvent.error.flatten());
+      return createErrorResponse(400, 'Invalid request structure', {
+        issues: parsedEvent.error.issues
+      });
+    }
+
+    let workingEvent: ValidatedEvent<Body, Query, Path> = {
+      ...(event as ValidatedEvent<Body, Query, Path>),
+      ...parsedEvent.data
+    };
+
+    if (options.querySchema) {
+      const queryParse = options.querySchema.safeParse(workingEvent.queryStringParameters || {});
+      if (!queryParse.success) {
+        console.warn('Query validation failed', queryParse.error.flatten());
+        return createErrorResponse(400, 'Invalid query parameters', {
+          issues: queryParse.error.issues
+        });
+      }
+      workingEvent = { ...workingEvent, validatedQuery: queryParse.data };
+    }
+
+    if (options.pathSchema) {
+      const pathParse = options.pathSchema.safeParse(workingEvent.pathParameters || {});
+      if (!pathParse.success) {
+        console.warn('Path validation failed', pathParse.error.flatten());
+        return createErrorResponse(400, 'Invalid path parameters', {
+          issues: pathParse.error.issues
+        });
+      }
+      workingEvent = { ...workingEvent, validatedPath: pathParse.data };
+    }
+
+    const method = (workingEvent.httpMethod || '').toUpperCase();
+
+    if (options.bodySchema && method !== 'OPTIONS') {
+      let rawBody: string | null = null;
+      try {
+        rawBody = decodeBody(workingEvent);
+      } catch (error) {
+        if ((error as Error).message === 'INVALID_BASE64_BODY') {
+          return createErrorResponse(400, 'Invalid request body encoding');
+        }
+        throw error;
+      }
+
+      if (rawBody === null) {
+        return createErrorResponse(400, 'Request body is required');
+      }
+
+      let parsedBody: unknown = rawBody;
+      const shouldParseJson = options.parseJsonBody ?? true;
+      if (shouldParseJson) {
+        try {
+          parsedBody = rawBody.length ? JSON.parse(rawBody) : {};
+        } catch (error) {
+          console.warn('JSON body parsing failed', error);
+          return createErrorResponse(400, 'Invalid JSON body');
+        }
+      }
+
+      const bodyParse = options.bodySchema.safeParse(parsedBody);
+      if (!bodyParse.success) {
+        console.warn('Body validation failed', bodyParse.error.flatten());
+        return createErrorResponse(400, 'Invalid request body', {
+          issues: bodyParse.error.issues
+        });
+      }
+
+      workingEvent = { ...workingEvent, validatedBody: bodyParse.data };
+    }
+
+    const response = await handler(workingEvent, context);
+
+    const parsedResponse = baseResponseSchema.safeParse(response);
+    if (!parsedResponse.success) {
+      console.error('Response structure validation failed', parsedResponse.error.flatten());
+      return createErrorResponse(500, 'Invalid response structure', {
+        issues: parsedResponse.error.issues
+      });
+    }
+
+    let finalResponse: APIGatewayProxyResult = {
+      ...(response as APIGatewayProxyResult),
+      ...parsedResponse.data
+    };
+
+    if (options.responseSchema && finalResponse.body) {
+      const ensureJson = options.ensureJsonResponse ?? true;
+      let parsedBody: unknown;
+
+      if (!finalResponse.body.length) {
+        parsedBody = {};
+      } else if (ensureJson) {
+        try {
+          parsedBody = JSON.parse(finalResponse.body);
+        } catch (error) {
+          console.error('Response body JSON parsing failed', error);
+          return createErrorResponse(500, 'Invalid JSON response body');
+        }
+      } else {
+        parsedBody = finalResponse.body;
+      }
+
+      const bodyValidation = options.responseSchema.safeParse(parsedBody);
+      if (!bodyValidation.success) {
+        console.error('Response body validation failed', bodyValidation.error.flatten());
+        return createErrorResponse(500, 'Response validation failed', {
+          issues: bodyValidation.error.issues
+        });
+      }
+
+      if (ensureJson) {
+        finalResponse = {
+          ...finalResponse,
+          body: JSON.stringify(bodyValidation.data)
+        };
+      }
+    }
+
+    return finalResponse;
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared `withRequestResponseValidation` helper that validates API Gateway events and responses with optional Zod schemas
- wrap every HTTP handler with the middleware and supply targeted schemas where request payloads or query strings require structured validation
- update login and checkout flows to rely on the middleware for JSON parsing and schema validation while preserving their existing business logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deee133634832f9ecf8af1543cc7cf