### PR TITLE
Optimize DynamoDB client pooling and reuse

### DIFF
--- a/src/ai/smartEvidenceCollector.ts
+++ b/src/ai/smartEvidenceCollector.ts
@@ -1,7 +1,7 @@
 import Stripe from 'stripe';
 import { z } from 'zod';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb } from '../shared/ddb';
 
 // Initialize Stripe client lazily
 let stripe: Stripe | null = null;
@@ -17,10 +17,6 @@ function getStripeClient(): Stripe {
   }
   return stripe;
 }
-
-// Initialize DynamoDB client
-const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' });
-const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 // Evidence bundle schema
 export const EvidenceBundleSchema = z.object({
@@ -439,7 +435,7 @@ async function collectCommunications(
   
   try {
     // Query communications table in DynamoDB
-    const response = await docClient.send(new QueryCommand({
+    const response = await ddb.send(new QueryCommand({
       TableName: process.env.COMMUNICATIONS_TABLE || 'communications',
       KeyConditionExpression: 'merchantId = :merchantId AND customerId = :customerId',
       ExpressionAttributeValues: {
@@ -567,7 +563,7 @@ function normalizePhone(phone: string): string {
 
 async function getTrackingFromDB(trackingNumber: string, merchantId: string): Promise<any> {
   try {
-    const response = await docClient.send(new GetCommand({
+    const response = await ddb.send(new GetCommand({
       TableName: process.env.TRACKING_TABLE || 'tracking',
       Key: {
         merchantId,
@@ -582,7 +578,7 @@ async function getTrackingFromDB(trackingNumber: string, merchantId: string): Pr
 
 async function getLoginHistory(customerId: string, merchantId: string): Promise<number> {
   try {
-    const response = await docClient.send(new QueryCommand({
+    const response = await ddb.send(new QueryCommand({
       TableName: process.env.ACTIVITY_TABLE || 'activity',
       KeyConditionExpression: 'merchantId = :merchantId AND customerId = :customerId',
       ExpressionAttributeValues: {

--- a/src/handlers/health-minimal.ts
+++ b/src/handlers/health-minimal.ts
@@ -1,4 +1,5 @@
-import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../shared/ddb";
 
 // Minimal Redis check without heavy imports
 async function checkRedis(): Promise<{ ok: boolean; error?: string }> {
@@ -36,7 +37,7 @@ async function checkRedis(): Promise<{ ok: boolean; error?: string }> {
   });
 }
 
-const dynamo = new DynamoDBClient({});
+const dynamo = dynamoClient;
 
 export const handler = async (_evt: any, ctx: any) => {
   if (ctx && typeof ctx === 'object') {

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,7 +1,8 @@
-import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { getRedisClient, isRedisReady } from "../cache/redisConnection";
+import { dynamoClient } from "../shared/ddb";
 
-const dynamo = new DynamoDBClient({});
+const dynamo = dynamoClient;
 
 const withTimeout = <T>(p: Promise<T>, ms = 350) =>
   Promise.race([

--- a/src/handlers/reportWeekly.ts
+++ b/src/handlers/reportWeekly.ts
@@ -1,8 +1,7 @@
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, ScanCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { ScanCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import { ddb } from "../shared/ddb";
 
-const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const ses = new SESClient({});
 
 const MERCHANTS = process.env.MERCHANTS_TABLE!;

--- a/src/handlers/statsHandler.ts
+++ b/src/handlers/statsHandler.ts
@@ -1,8 +1,9 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { ScanCommand } from '@aws-sdk/client-dynamodb';
 import Redis from 'ioredis';
+import { dynamoClient } from '../shared/ddb';
 
-const dynamodb = new DynamoDBClient({ region: 'us-east-1' });
+const dynamodb = dynamoClient;
 const CASES_TABLE = process.env.CASES_TABLE || 'chargeback-autopilot-stripe-prod-CasesTable-1LPIUKCN82FYI';
 const CACHE_TTL = 300; // 5 minutes cache
 

--- a/src/shared/ddb.ts
+++ b/src/shared/ddb.ts
@@ -1,8 +1,58 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { Agent } from "node:https";
 
 const REGION = process.env.AWS_REGION || "us-east-1";
-const client = new DynamoDBClient({ region: REGION });
-export const ddb = DynamoDBDocumentClient.from(client, {
-  marshallOptions: { removeUndefinedValues: true }
+const MAX_SOCKETS = Number(process.env.DDB_MAX_SOCKETS ?? 50);
+const CONNECTION_TIMEOUT = Number(process.env.DDB_CONNECTION_TIMEOUT ?? 5000);
+const SOCKET_TIMEOUT = Number(process.env.DDB_SOCKET_TIMEOUT ?? 5000);
+
+const httpsAgent = new Agent({
+  keepAlive: true,
+  maxSockets: MAX_SOCKETS,
 });
+
+const requestHandler = new NodeHttpHandler({
+  connectionTimeout: CONNECTION_TIMEOUT,
+  socketTimeout: SOCKET_TIMEOUT,
+  httpsAgent,
+});
+
+const createNativeClient = () =>
+  new DynamoDBClient({
+    region: REGION,
+    maxAttempts: Number(process.env.DDB_MAX_ATTEMPTS ?? 3),
+    requestHandler,
+  });
+
+const createDocumentClient = (client: DynamoDBClient) =>
+  DynamoDBDocumentClient.from(client, {
+    marshallOptions: { removeUndefinedValues: true },
+  });
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __DDB_NATIVE_CLIENT__: DynamoDBClient | undefined;
+  // eslint-disable-next-line no-var
+  var __DDB_DOC_CLIENT__: DynamoDBDocumentClient | undefined;
+}
+
+const getNativeClient = (): DynamoDBClient => {
+  if (!globalThis.__DDB_NATIVE_CLIENT__) {
+    globalThis.__DDB_NATIVE_CLIENT__ = createNativeClient();
+  }
+
+  return globalThis.__DDB_NATIVE_CLIENT__;
+};
+
+const getDocumentClient = (): DynamoDBDocumentClient => {
+  if (!globalThis.__DDB_DOC_CLIENT__) {
+    globalThis.__DDB_DOC_CLIENT__ = createDocumentClient(getNativeClient());
+  }
+
+  return globalThis.__DDB_DOC_CLIENT__;
+};
+
+export const dynamoClient = getNativeClient();
+export const ddb = getDocumentClient();

--- a/src/shared/webhookIdempotency.ts
+++ b/src/shared/webhookIdempotency.ts
@@ -1,8 +1,5 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
-
-const client = new DynamoDBClient({});
-const ddb = DynamoDBDocumentClient.from(client);
+import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb } from './ddb';
 
 const IDEMPOTENCY_TABLE = process.env.CASES_TABLE || 'CasesTable';
 const IDEMPOTENCY_TTL_HOURS = 24;

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,9 +1,7 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { ddb } from './ddb';
 
-const client = new DynamoDBClient({});
-const ddb = DynamoDBDocumentClient.from(client);
 const ssm = new SSMClient({});
 
 const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE || 'MerchantsTable';


### PR DESCRIPTION
## Summary
- add a shared DynamoDB connection manager with keep-alive pooling for client reuse
- refactor idempotency, webhook, health, stats, and evidence collection modules to leverage the pooled client
- ensure all DynamoDB access paths share the optimized connection strategy

## Testing
- npm run build *(fails: src/handlers/buildEvidence.ts(207,23): Property 'fraudWarning' does not exist on type 'EvidencePackage'.)*

------
https://chatgpt.com/codex/tasks/task_e_68deede8e2f8832f9f6c92c9a16df9af