### PR TITLE
Add per-merchant API rate limiting

### DIFF
--- a/src/handlers/collectCase.ts
+++ b/src/handlers/collectCase.ts
@@ -2,6 +2,7 @@ import { bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { StartExecutionCommand, SFNClient as StepFunctionsClient } from "@aws-sdk/client-sfn";
+import { rateLimitMiddleware } from "../shared/rateLimit.js";
 
 const sfn = new StepFunctionsClient({});
 
@@ -26,6 +27,15 @@ export async function handler(event:any){
       statusCode: 403,
       body: JSON.stringify({ error: 'Access denied to this merchant account' })
     };
+  }
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId,
+    identifierSuffix: id
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
   }
 
   await sfn.send(new StartExecutionCommand({

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -3,6 +3,7 @@ import { requireAuth, verifyMerchantOwnership } from '../shared/auth.js';
 import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
 import Stripe from 'stripe';
+import { rateLimitMiddleware } from '../shared/rateLimit.js';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -88,6 +89,15 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         headers,
         body: JSON.stringify({ error: 'Access denied to this merchant account' })
       };
+    }
+
+    const rateLimitResult = await rateLimitMiddleware(event, {
+      authContext,
+      merchantId,
+      identifierSuffix: input.status || 'all'
+    });
+    if (rateLimitResult) {
+      return { ...rateLimitResult, headers: { ...headers, ...(rateLimitResult.headers || {}) } };
     }
     
     // Get REAL disputes from Stripe

--- a/src/handlers/getCase.ts
+++ b/src/handlers/getCase.ts
@@ -2,6 +2,7 @@ import { ok, bad } from "../shared/responses.js";
 import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { validationMiddleware, commonSchemas } from "../shared/validation.js";
+import { rateLimitMiddleware } from "../shared/rateLimit.js";
 
 export async function handler(event:any){
   // Validate input first
@@ -40,6 +41,15 @@ export async function handler(event:any){
       statusCode: 403,
       body: JSON.stringify({ error: 'Access denied to this merchant account' })
     };
+  }
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId,
+    identifierSuffix: id
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
   }
   
   const item = await getCase(merchantId, id);

--- a/src/handlers/getUserDisputes.ts
+++ b/src/handlers/getUserDisputes.ts
@@ -1,6 +1,7 @@
 import { ok, bad } from "../shared/responses.js";
 import { listCases } from "../shared/db.js";
 import { requireAuth } from "../shared/auth.js";
+import { rateLimitMiddleware } from "../shared/rateLimit.js";
 
 /**
  * Get disputes for the authenticated user only
@@ -25,6 +26,15 @@ export async function handler(event: any) {
   // Get query parameters
   const qs = event.queryStringParameters || {};
   const status = qs.status; // optional filter by status
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId: authContext.merchant_id,
+    identifierSuffix: status || 'all'
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
+  }
   
   try {
     // Get disputes for this user's merchant account only

--- a/src/handlers/listCases.ts
+++ b/src/handlers/listCases.ts
@@ -21,12 +21,6 @@ function getRedis() {
 }
 
 export async function handler(event:any){
-  // Check rate limit first
-  const rateLimitResult = await rateLimitMiddleware(event);
-  if (rateLimitResult) {
-    return rateLimitResult; // Return 429 if rate limited
-  }
-  
   // Validate input
   const validationSchema = {
     ...commonSchemas.merchantId,
@@ -63,6 +57,15 @@ export async function handler(event:any){
       statusCode: 403,
       body: JSON.stringify({ error: 'Access denied to this merchant account' })
     };
+  }
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId,
+    identifierSuffix: input.status || 'all'
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
   }
   
   // Try Redis cache first for performance

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { rateLimitMiddleware } from "../shared/rateLimit.js";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -16,6 +17,15 @@ export async function handler(event: any) {
   
   if (!authContext.merchant_id) {
     return bad('No Stripe account connected');
+  }
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId: authContext.merchant_id,
+    identifierSuffix: 'refresh-token'
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
   }
   
   try {

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -1,6 +1,7 @@
 import { ok, bad, createErrorResponse } from "../shared/responses.js";
 import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
+import { rateLimitMiddleware } from "../shared/rateLimit.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
 import Stripe from 'stripe';
 
@@ -32,6 +33,15 @@ export async function handler(event: any) {
     return createErrorResponse(403, 'Access denied', {
       error: 'You do not have access to this merchant account'
     });
+  }
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId,
+    identifierSuffix: disputeId
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
   }
   
   try {

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -1,6 +1,7 @@
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
+import { rateLimitMiddleware } from "../shared/rateLimit.js";
 import Stripe from 'stripe';
 import { 
   predictWinRate, 
@@ -72,6 +73,15 @@ export async function handler(event:any){
       statusCode: 403,
       body: JSON.stringify({ error: 'Access denied to this merchant account' })
     };
+  }
+
+  const rateLimitResult = await rateLimitMiddleware(event, {
+    authContext,
+    merchantId,
+    identifierSuffix: id
+  });
+  if (rateLimitResult) {
+    return rateLimitResult;
   }
 
   try {

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -88,16 +88,24 @@ export async function validateAuth(authHeader: string | undefined): Promise<Auth
  * Middleware to require authentication
  */
 export async function requireAuth(event: any): Promise<AuthContext | { statusCode: number; body: string }> {
+  if (event && (event as any).authContext) {
+    return (event as any).authContext as AuthContext;
+  }
+
   const authHeader = event.headers?.Authorization || event.headers?.authorization;
   const authContext = await validateAuth(authHeader);
-  
+
   if (!authContext) {
     return {
       statusCode: 401,
       body: JSON.stringify({ error: 'Unauthorized' })
     };
   }
-  
+
+  if (event) {
+    (event as any).authContext = authContext;
+  }
+
   return authContext;
 }
 

--- a/src/shared/rateLimit.ts
+++ b/src/shared/rateLimit.ts
@@ -1,6 +1,7 @@
 import { createErrorResponse } from './responses.js';
 import { ddb } from './ddb.js';
 import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { AuthContext, validateAuth } from './auth.js';
 
 const RATE_LIMIT_TABLE = process.env.CASES_TABLE!; // Reuse cases table
 
@@ -8,6 +9,19 @@ interface RateLimitConfig {
   maxRequests: number;
   windowSeconds: number;
   identifier: string;
+}
+
+interface RateLimitContext {
+  userId?: string;
+  merchantId?: string;
+  identifierSuffix?: string;
+}
+
+interface RateLimitOptions {
+  authContext?: AuthContext | null;
+  merchantId?: string | null;
+  identifierSuffix?: string;
+  skipAuthLookup?: boolean;
 }
 
 /**
@@ -60,32 +74,40 @@ export async function checkRateLimit(config: RateLimitConfig): Promise<boolean> 
 /**
  * Get rate limit configuration for different API endpoints
  */
-export function getRateLimitConfig(path: string, sourceIp: string): RateLimitConfig {
+export function getRateLimitConfig(path: string, sourceIp: string, context: RateLimitContext = {}): RateLimitConfig {
+  const scope = context.merchantId
+    ? `merchant:${context.merchantId}`
+    : context.userId
+      ? `user:${context.userId}`
+      : `ip:${sourceIp}`;
+
+  const suffix = context.identifierSuffix ? `:${context.identifierSuffix}` : '';
+
   // Different limits for different endpoints
   if (path.includes('/webhook')) {
     return {
       maxRequests: 1000, // 1000 webhook events per minute
       windowSeconds: 60,
-      identifier: `webhook:${sourceIp}`
+      identifier: `webhook:${scope}${suffix}`
     };
   } else if (path.includes('/cases')) {
     return {
       maxRequests: 100, // 100 requests per minute for cases endpoint
       windowSeconds: 60,
-      identifier: `cases:${sourceIp}`
+      identifier: `cases:${scope}${suffix}`
     };
   } else if (path.includes('/auth')) {
     return {
       maxRequests: 20, // 20 auth attempts per minute
       windowSeconds: 60,
-      identifier: `auth:${sourceIp}`
+      identifier: `auth:${scope}${suffix}`
     };
   } else {
     // Default rate limit
     return {
       maxRequests: 200, // 200 requests per minute default
       windowSeconds: 60,
-      identifier: `default:${sourceIp}`
+      identifier: `default:${scope}${suffix}`
     };
   }
 }
@@ -93,13 +115,39 @@ export function getRateLimitConfig(path: string, sourceIp: string): RateLimitCon
 /**
  * Express-style middleware for rate limiting
  */
-export async function rateLimitMiddleware(event: any): Promise<any> {
+export async function rateLimitMiddleware(event: any, options: RateLimitOptions = {}): Promise<any> {
   const sourceIp = event.requestContext?.identity?.sourceIp || 'unknown';
   const path = event.path || '/';
-  
-  const config = getRateLimitConfig(path, sourceIp);
+
+  let authContext = options.authContext ?? (event?.authContext as AuthContext | undefined);
+
+  if (!authContext && !options.skipAuthLookup) {
+    try {
+      const authHeader = event.headers?.Authorization || event.headers?.authorization;
+      if (authHeader) {
+        authContext = await validateAuth(authHeader) ?? undefined;
+        if (authContext) {
+          (event as any).authContext = authContext;
+        }
+      }
+    } catch (error) {
+      console.warn('Rate limit auth lookup failed:', error);
+    }
+  }
+
+  const merchantId = options.merchantId
+    ?? event?.queryStringParameters?.merchant
+    ?? authContext?.merchant_id
+    ?? authContext?.stripe_account_id
+    ?? undefined;
+
+  const config = getRateLimitConfig(path, sourceIp, {
+    userId: authContext?.uid,
+    merchantId,
+    identifierSuffix: options.identifierSuffix
+  });
   const allowed = await checkRateLimit(config);
-  
+
   if (!allowed) {
     return createErrorResponse(429, 'Too Many Requests', {
       message: 'Rate limit exceeded. Please try again later.',


### PR DESCRIPTION
## Summary
- update the shared rate limit middleware to derive identifiers from authenticated users and merchants
- cache auth context on Lambda events so rate limiting can reuse it without extra token checks
- apply the updated middleware across dispute and evidence handlers to enforce per-merchant throttling

## Testing
- npm run build *(fails: src/handlers/buildEvidence.ts(207,23): error TS2339: Property 'fraudWarning' does not exist on type 'EvidencePackage'.)*

------
https://chatgpt.com/codex/tasks/task_e_68deebb8e010832f8661f60bf85f0a06