### PR TITLE
Add startup environment validation

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,6 +1,7 @@
 import { putMerchant } from "../shared/db.js";
 import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { env } from "../shared/env.js";
 
 export async function handler(event:any){
   const qs = event.queryStringParameters || {};
@@ -10,8 +11,8 @@ export async function handler(event:any){
   if(!code) return { statusCode:400, body:'missing code' };
 
   const body = new URLSearchParams({
-    client_secret: process.env.STRIPE_SECRET!,
-    client_id: process.env.STRIPE_CLIENT_ID!,
+    client_secret: env.STRIPE_SECRET,
+    client_id: env.STRIPE_CLIENT_ID,
     code, grant_type: 'authorization_code'
   });
 
@@ -73,7 +74,7 @@ export async function handler(event:any){
 
   // Register webhook endpoint for this connected account
   try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+    const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
     const webhookEndpoint = await stripe.webhookEndpoints.create({
       url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
       enabled_events: [

--- a/src/handlers/authStripeStart.ts
+++ b/src/handlers/authStripeStart.ts
@@ -1,8 +1,9 @@
 import crypto from 'crypto';
 import { ok, bad } from "../shared/responses.js";
+import { env } from "../shared/env.js";
 
-const STRIPE_CLIENT_ID = process.env.STRIPE_CLIENT_ID!;
-const STRIPE_REDIRECT_URI = process.env.STRIPE_REDIRECT_URI!;
+const STRIPE_CLIENT_ID = env.STRIPE_CLIENT_ID;
+const STRIPE_REDIRECT_URI = env.STRIPE_REDIRECT_URI;
 
 export async function handler(event: any){
   if(!STRIPE_CLIENT_ID || !STRIPE_REDIRECT_URI) return bad("Stripe not configured");

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,13 +1,14 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { env } from "../shared/env.js";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
  * Should run daily via EventBridge
  */
 export async function handler(event: any) {
-  const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE!;
+  const MERCHANTS_TABLE = env.MERCHANTS_TABLE;
   const REFRESH_BEFORE_HOURS = 24; // Refresh tokens 24 hours before expiry
   
   try {
@@ -46,7 +47,7 @@ export async function handler(event: any) {
           const body = new URLSearchParams({
             grant_type: 'refresh_token',
             refresh_token: merchant.refresh_token,
-            client_secret: process.env.STRIPE_SECRET!
+            client_secret: env.STRIPE_SECRET
           });
           
           const response = await fetch('https://connect.stripe.com/oauth/token', {

--- a/src/handlers/collectCase.ts
+++ b/src/handlers/collectCase.ts
@@ -2,6 +2,7 @@ import { bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { StartExecutionCommand, SFNClient as StepFunctionsClient } from "@aws-sdk/client-sfn";
+import { env } from "../shared/env.js";
 
 const sfn = new StepFunctionsClient({});
 
@@ -29,7 +30,7 @@ export async function handler(event:any){
   }
 
   await sfn.send(new StartExecutionCommand({
-    stateMachineArn: process.env.SFN_ARN!,
+    stateMachineArn: env.SFN_ARN,
     input: JSON.stringify({ merchant: { stripe_account_id: merchantId }, dispute_id: id })
   }));
 

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -1,8 +1,9 @@
 import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
+import { env } from "../shared/env.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
   // Get auth context if user is logged in (optional for checkout)

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -3,8 +3,9 @@ import { requireAuth, verifyMerchantOwnership } from '../shared/auth.js';
 import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
 import Stripe from 'stripe';
+import { env } from '../shared/env.js';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
 
 interface Dispute {
   id: string;

--- a/src/handlers/getCharge.ts
+++ b/src/handlers/getCharge.ts
@@ -1,5 +1,7 @@
 import Stripe from 'stripe';
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+import { env } from '../shared/env.js';
+
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
 
 export async function handler(evt:any){
   // Safely extract stripe_account_id with proper error handling

--- a/src/handlers/getDispute.ts
+++ b/src/handlers/getDispute.ts
@@ -1,7 +1,8 @@
 import Stripe from 'stripe';
 import { getMerchantByAccount, upsertCase } from "../shared/db.js";
+import { env } from "../shared/env.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
 
 export async function handler(evt:any){
   const { dispute_id, merchant: { stripe_account_id } } = evt;

--- a/src/handlers/getPaymentIntent.ts
+++ b/src/handlers/getPaymentIntent.ts
@@ -1,5 +1,7 @@
 import Stripe from 'stripe';
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+import { env } from '../shared/env.js';
+
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
 
 export async function handler(evt:any){
   const { charge, merchant:{stripe_account_id} } = evt;

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { getRedisClient, isRedisReady } from "../cache/redisConnection";
+import { env } from "../shared/env.js";
 
 const dynamo = new DynamoDBClient({});
 
@@ -41,7 +42,7 @@ export const handler = async (_evt: any, ctx: any) => {
   try {
     await withTimeout(
       dynamo.send(new GetItemCommand({
-        TableName: process.env.CASES_TABLE!,
+        TableName: env.CASES_TABLE,
         Key: { pk: { S: "canary" }, sk: { S: "health" } }
       })), 
       300

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { env } from "../shared/env.js";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -30,7 +31,7 @@ export async function handler(event: any) {
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: merchant.refresh_token,
-      client_secret: process.env.STRIPE_SECRET!
+      client_secret: env.STRIPE_SECRET
     });
     
     const response = await fetch('https://connect.stripe.com/oauth/token', {

--- a/src/handlers/reportWeekly.ts
+++ b/src/handlers/reportWeekly.ts
@@ -1,13 +1,14 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, ScanCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import { env } from "../shared/env.js";
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const ses = new SESClient({});
 
-const MERCHANTS = process.env.MERCHANTS_TABLE!;
-const CASES = process.env.CASES_TABLE!;
-const SES_FROM = process.env.SES_FROM!;
+const MERCHANTS = env.MERCHANTS_TABLE;
+const CASES = env.CASES_TABLE;
+const SES_FROM = env.SES_FROM;
 const SES_DEFAULT_TO = process.env.SES_DEFAULT_TO || '';
 
 const OPEN = new Set(['needs_response','warning_needs_response','under_review','warning_under_review']);

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -3,9 +3,10 @@ import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
 import Stripe from 'stripe';
+import { env } from "../shared/env.js";
 
 const sfn = new SFNClient({});
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
   // REQUIRE AUTHENTICATION
@@ -84,10 +85,10 @@ export async function handler(event: any) {
     };
     
     // Start Step Functions execution for retry
-    if (process.env.SFN_ARN) {
+    if (env.SFN_ARN) {
       const executionName = `retry-${disputeId}-${Date.now()}`;
       await sfn.send(new StartExecutionCommand({
-        stateMachineArn: process.env.SFN_ARN,
+        stateMachineArn: env.SFN_ARN,
         name: executionName,
         input: JSON.stringify(sfnInput)
       }));

--- a/src/handlers/stripeStageEvidence.ts
+++ b/src/handlers/stripeStageEvidence.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { env } from '../shared/env.js';
 
 export async function handler(evt:any){
   const { dispute, evidence, merchant } = evt;
@@ -12,11 +13,11 @@ export async function handler(evt:any){
     stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil' });
   } else if (merchant?.stripe_account_id) {
     // Standard connected account - use global secret with stripeAccount header
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
     stripeOptions = { stripeAccount: merchant.stripe_account_id };
   } else {
     // Direct account - use global secret
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
   }
   
   const res = await stripe.disputes.update(dispute.id, { evidence, submit: false }, stripeOptions);

--- a/src/handlers/stripeSubmitEvidence.ts
+++ b/src/handlers/stripeSubmitEvidence.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { env } from '../shared/env.js';
 
 export async function handler(evt:any){
   const { dispute, merchant } = evt;
@@ -12,11 +13,11 @@ export async function handler(evt:any){
     stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil' });
   } else if (merchant?.stripe_account_id) {
     // Standard connected account - use global secret with stripeAccount header
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
     stripeOptions = { stripeAccount: merchant.stripe_account_id };
   } else {
     // Direct account - use global secret
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
   }
   
   const res = await stripe.disputes.update(dispute.id, { submit: true }, stripeOptions);

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -2,15 +2,15 @@ import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import Stripe from 'stripe';
-import { 
-  predictWinRate, 
+import {
+  predictWinRate,
   shouldSubmit,
   expectedValue,
   isAIEnabled,
   type Features
 } from '../ai';
 import { CloudWatch, StandardUnit } from '@aws-sdk/client-cloudwatch';
-import { 
+import {
   getMerchantWinRate,
   getCustomerTransactionCount,
   getCustomerTenureDays,
@@ -20,8 +20,9 @@ import {
 } from "../shared/db-helpers.js";
 import { CE3Detector } from "../ce3-engine/ce3Detector.js";
 import { TimingOptimizer } from "../ai-features/timingOptimizer.js";
+import { env } from "../shared/env.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion:'2025-07-30.basil' });
 const cloudwatch = new CloudWatch({});
 
 // Helper to publish metrics

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -3,8 +3,9 @@ import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
 import Stripe from 'stripe';
+import { env } from "../shared/env.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
 
 // Handle subscription lifecycle events
 export async function handleSubscriptionEvent(event: any, subscriptionEvent: any) {

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -5,6 +5,7 @@ import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
 import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { env } from "../shared/env.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -50,10 +51,10 @@ if (process.env.ENABLE_MODEL_UPDATER === 'true') {
   }
 }
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
 const sfn = new SFNClient({});
 const cloudwatch = new CloudWatch({});
-const WEBHOOK_EVENTS_TABLE = process.env.CASES_TABLE!; // Reuse cases table for webhook events
+const WEBHOOK_EVENTS_TABLE = env.CASES_TABLE; // Reuse cases table for webhook events
 
 // Helper to publish metrics
 async function publishMetric(name: string, value: number, unit: string = 'Count') {
@@ -373,9 +374,9 @@ export async function handler(event:any){
       };
       
       // Only start Step Functions if configured
-      if (process.env.SFN_ARN) {
+      if (env.SFN_ARN) {
         await sfn.send(new StartExecutionCommand({
-          stateMachineArn: process.env.SFN_ARN,
+          stateMachineArn: env.SFN_ARN,
           input: JSON.stringify(sfnInput)
         }));
       }
@@ -387,12 +388,12 @@ export async function handler(event:any){
       
       try {
         // 1. Extract all features (34+ features)
-        const featureExtractor = new FeatureExtractor(process.env.STRIPE_SECRET!);
+        const featureExtractor = new FeatureExtractor(env.STRIPE_SECRET);
         const features = await featureExtractor.extractAllFeatures(dispute);
         
         // 2. Get our original prediction (if exists)
         const caseData = await ddb.send(new GetCommand({
-          TableName: process.env.CASES_TABLE!,
+          TableName: env.CASES_TABLE,
           Key: {
             pk: `MERCHANT#${eventAccount}`,
             sk: `DISPUTE#${dispute.id}`

--- a/src/shared/auditLog.ts
+++ b/src/shared/auditLog.ts
@@ -1,8 +1,9 @@
 import { ddb } from './ddb.js';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { v4 as uuidv4 } from 'uuid';
+import { env } from './env.js';
 
-const AUDIT_TABLE = process.env.AUDIT_TABLE || process.env.CASES_TABLE!;
+const AUDIT_TABLE = env.AUDIT_TABLE ?? env.CASES_TABLE;
 
 export enum AuditAction {
   // Authentication

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,6 +1,7 @@
 import admin from 'firebase-admin';
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "./ddb.js";
+import { env } from "./env.js";
 
 // Initialize Firebase Admin SDK
 let firebaseApp: admin.app.App | null = null;
@@ -59,7 +60,7 @@ export async function validateAuth(authHeader: string | undefined): Promise<Auth
     try {
       // Try to find merchant by firebase_uid
       const result = await ddb.send(new GetCommand({
-        TableName: process.env.MERCHANTS_TABLE!,
+        TableName: env.MERCHANTS_TABLE,
         Key: { pk: `USER#${decodedToken.uid}` }
       }));
       
@@ -117,7 +118,7 @@ export async function verifyMerchantOwnership(
   // Double-check in database
   try {
     const result = await ddb.send(new GetCommand({
-      TableName: process.env.MERCHANTS_TABLE!,
+      TableName: env.MERCHANTS_TABLE,
       Key: { pk: `MERCHANT#${merchantId}` }
     }));
     

--- a/src/shared/db-helpers.ts
+++ b/src/shared/db-helpers.ts
@@ -5,10 +5,11 @@
 
 import { ddb } from "./ddb.js";
 import { QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { env } from "./env.js";
 
-const CASES = process.env.CASES_TABLE!;
-const MERCHANTS = process.env.MERCHANTS_TABLE!;
-const SUBMISSIONS = process.env.SUBMISSIONS_TABLE!;
+const CASES = env.CASES_TABLE;
+const MERCHANTS = env.MERCHANTS_TABLE;
+const SUBMISSIONS = env.SUBMISSIONS_TABLE;
 
 /**
  * Calculate REAL merchant win rate from historical cases

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,8 +1,9 @@
 import { ddb } from "./ddb.js";
 import { PutCommand, GetCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { env } from "./env.js";
 
-const MERCHANTS = process.env.MERCHANTS_TABLE!;
-const CASES = process.env.CASES_TABLE!;
+const MERCHANTS = env.MERCHANTS_TABLE;
+const CASES = env.CASES_TABLE;
 
 export async function putMerchant(m:any){
   // Use stripe_account_id as the primary key for consistency

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const envSchema = z
+  .object({
+    STRIPE_SECRET: z.string().min(1, "STRIPE_SECRET is required"),
+    STRIPE_CLIENT_ID: z.string().min(1, "STRIPE_CLIENT_ID is required"),
+    STRIPE_REDIRECT_URI: z.string().min(1, "STRIPE_REDIRECT_URI is required"),
+    MERCHANTS_TABLE: z.string().min(1, "MERCHANTS_TABLE is required"),
+    CASES_TABLE: z.string().min(1, "CASES_TABLE is required"),
+    SUBMISSIONS_TABLE: z.string().min(1, "SUBMISSIONS_TABLE is required"),
+    SES_FROM: z.string().min(1, "SES_FROM is required"),
+    SFN_ARN: z.string().min(1, "SFN_ARN is required"),
+    AUDIT_TABLE: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+type AppEnv = z.infer<typeof envSchema>;
+
+const result = envSchema.safeParse(process.env);
+
+if (!result.success) {
+  const details = result.error.issues
+    .map((issue) => `- ${issue.path.join('.')}: ${issue.message}`)
+    .join('\n');
+
+  throw new Error(`Environment validation failed:\n${details}`);
+}
+
+export const env: AppEnv = result.data;

--- a/src/shared/rateLimit.ts
+++ b/src/shared/rateLimit.ts
@@ -1,8 +1,9 @@
 import { createErrorResponse } from './responses.js';
 import { ddb } from './ddb.js';
 import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { env } from './env.js';
 
-const RATE_LIMIT_TABLE = process.env.CASES_TABLE!; // Reuse cases table
+const RATE_LIMIT_TABLE = env.CASES_TABLE; // Reuse cases table
 
 interface RateLimitConfig {
   maxRequests: number;

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,12 +1,13 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { env } from './env.js';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
 const ssm = new SSMClient({});
 
-const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE || 'MerchantsTable';
+const MERCHANTS_TABLE = env.MERCHANTS_TABLE || 'MerchantsTable';
 
 /**
  * Get the webhook secret for a specific merchant account
@@ -83,7 +84,7 @@ export async function validateWebhookSignature(
   accountId?: string
 ): Promise<boolean> {
   const Stripe = require('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+  const stripe = new Stripe(env.STRIPE_SECRET, { apiVersion: '2025-07-30.basil' });
   
   try {
     // Get the appropriate webhook secret


### PR DESCRIPTION
## Summary
- add a shared environment configuration module that validates required variables at startup
- update shared data access utilities and Lambda handlers to depend on the validated configuration instead of direct process.env usage
- extend evidence package typing to support ML fraud warnings without TypeScript errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68deeb900b78832fbb683d5170419466