### PR TITLE
Add circuit breaker safeguards for external dependencies

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,6 +1,7 @@
 import { putMerchant } from "../shared/db.js";
 import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { fetchWithCircuitBreaker, stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 
 export async function handler(event:any){
   const qs = event.queryStringParameters || {};
@@ -15,9 +16,17 @@ export async function handler(event:any){
     code, grant_type: 'authorization_code'
   });
 
-  const r = await fetch('https://connect.stripe.com/oauth/token', {
-    method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
-  });
+  const r = await fetchWithCircuitBreaker(
+    'https://connect.stripe.com/oauth/token',
+    {
+      method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
+    },
+    {
+      breakerId: 'stripe:oauth.exchange',
+      failureThreshold: 3,
+      cooldownPeriod: 60_000
+    }
+  );
   const json:any = await r.json();
   if(!json.stripe_user_id) return { statusCode:400, body:`oauth failed: ${JSON.stringify(json)}` };
 
@@ -74,17 +83,24 @@ export async function handler(event:any){
   // Register webhook endpoint for this connected account
   try {
     const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
-    const webhookEndpoint = await stripe.webhookEndpoints.create({
-      url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
-      enabled_events: [
-        'charge.dispute.created',
-        'charge.dispute.updated', 
-        'charge.dispute.closed',
-        'charge.dispute.funds_reinstated',
-        'charge.dispute.funds_withdrawn'
-      ],
-      connect: true // This makes it a Connect webhook
-    });
+    const webhookEndpoint = await stripeCircuitBreaker(
+      'webhookEndpoints.create',
+      () => stripe.webhookEndpoints.create({
+        url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
+        enabled_events: [
+          'charge.dispute.created',
+          'charge.dispute.updated',
+          'charge.dispute.closed',
+          'charge.dispute.funds_reinstated',
+          'charge.dispute.funds_withdrawn'
+        ],
+        connect: true // This makes it a Connect webhook
+      }),
+      {
+        failureThreshold: 3,
+        cooldownPeriod: 120_000
+      }
+    );
     
     console.log('Webhook endpoint registered:', webhookEndpoint.id);
     

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,7 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { fetchWithCircuitBreaker } from "../shared/circuitBreaker.js";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -49,11 +50,19 @@ export async function handler(event: any) {
             client_secret: process.env.STRIPE_SECRET!
           });
           
-          const response = await fetch('https://connect.stripe.com/oauth/token', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body
-          });
+          const response = await fetchWithCircuitBreaker(
+            'https://connect.stripe.com/oauth/token',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body
+            },
+            {
+              breakerId: 'stripe:oauth.refresh',
+              failureThreshold: 3,
+              cooldownPeriod: 60_000
+            }
+          );
           
           const json: any = await response.json();
           

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
+import { stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -26,48 +27,69 @@ export async function handler(event: any) {
   
   try {
     // Create or retrieve customer
-    const customers = await stripe.customers.list({
-      email: email,
-      limit: 1
-    });
+    const customers = await stripeCircuitBreaker(
+      'customers.list',
+      () => stripe.customers.list({
+        email: email,
+        limit: 1
+      }),
+      {
+        failureThreshold: 3,
+        cooldownPeriod: 90_000
+      }
+    );
     
     let customer;
     if (customers.data.length > 0) {
       customer = customers.data[0];
     } else {
-      customer = await stripe.customers.create({
-        email: email,
-        metadata: {
-          firebase_uid: authContext?.uid || '',
-          source: 'stripedshield_checkout'
+      customer = await stripeCircuitBreaker(
+        'customers.create',
+        () => stripe.customers.create({
+          email: email,
+          metadata: {
+            firebase_uid: authContext?.uid || '',
+            source: 'stripedshield_checkout'
+          }
+        }),
+        {
+          failureThreshold: 3,
+          cooldownPeriod: 90_000
         }
-      });
+      );
     }
     
     // Create checkout session
-    const session = await stripe.checkout.sessions.create({
-      customer: customer.id,
-      payment_method_types: ['card'],
-      mode: 'subscription',
-      line_items: [{
-        price: priceId,
-        quantity: 1
-      }],
-      subscription_data: {
-        trial_period_days: 7,
+    const session = await stripeCircuitBreaker(
+      'checkout.sessions.create',
+      () => stripe.checkout.sessions.create({
+        customer: customer.id,
+        payment_method_types: ['card'],
+        mode: 'subscription',
+        line_items: [{
+          price: priceId,
+          quantity: 1
+        }],
+        subscription_data: {
+          trial_period_days: 7,
+          metadata: {
+            firebase_uid: authContext?.uid || '',
+            merchant_id: authContext?.merchant_id || ''
+          }
+        },
+        success_url: 'https://stripedshield-founders-1755231149.netlify.app/dashboard-protected.html?payment=success',
+        cancel_url: 'https://stripedshield-founders-1755231149.netlify.app/checkout.html?payment=cancelled',
+        client_reference_id: authContext?.uid || email, // Link to Firebase user
         metadata: {
           firebase_uid: authContext?.uid || '',
-          merchant_id: authContext?.merchant_id || ''
+          email: email
         }
-      },
-      success_url: 'https://stripedshield-founders-1755231149.netlify.app/dashboard-protected.html?payment=success',
-      cancel_url: 'https://stripedshield-founders-1755231149.netlify.app/checkout.html?payment=cancelled',
-      client_reference_id: authContext?.uid || email, // Link to Firebase user
-      metadata: {
-        firebase_uid: authContext?.uid || '',
-        email: email
+      }),
+      {
+        failureThreshold: 3,
+        cooldownPeriod: 90_000
       }
-    });
+    );
     
     return ok({ 
       checkout_url: session.url,

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -3,6 +3,7 @@ import { requireAuth, verifyMerchantOwnership } from '../shared/auth.js';
 import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from '../shared/circuitBreaker.js';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -91,9 +92,16 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
     
     // Get REAL disputes from Stripe
-    const stripeDisputes = await stripe.disputes.list(
-      { limit: 100 },
-      { stripeAccount: merchantId }
+    const stripeDisputes = await stripeCircuitBreaker(
+      'disputes.list',
+      () => stripe.disputes.list(
+        { limit: 100 },
+        { stripeAccount: merchantId }
+      ),
+      {
+        failureThreshold: 4,
+        cooldownPeriod: 120_000
+      }
     );
     
     // Get additional case data from database

--- a/src/handlers/getCharge.ts
+++ b/src/handlers/getCharge.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from '../shared/circuitBreaker.js';
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
 
 export async function handler(evt:any){
@@ -18,9 +19,16 @@ export async function handler(evt:any){
   
   try {
     // Retrieve charge with optional connected account
-    const ch = stripe_account_id 
-      ? await stripe.charges.retrieve(chargeId, { stripeAccount: stripe_account_id })
-      : await stripe.charges.retrieve(chargeId);
+    const ch = await stripeCircuitBreaker(
+      'charges.retrieve',
+      () => stripe_account_id
+        ? stripe.charges.retrieve(chargeId, { stripeAccount: stripe_account_id })
+        : stripe.charges.retrieve(chargeId),
+      {
+        failureThreshold: 4,
+        cooldownPeriod: 120_000
+      }
+    );
       
     return { ...evt, charge: ch };
   } catch (error: any) {

--- a/src/handlers/getDispute.ts
+++ b/src/handlers/getDispute.ts
@@ -1,12 +1,20 @@
 import Stripe from 'stripe';
 import { getMerchantByAccount, upsertCase } from "../shared/db.js";
+import { stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
 
 export async function handler(evt:any){
   const { dispute_id, merchant: { stripe_account_id } } = evt;
   const merchant = await getMerchantByAccount(stripe_account_id);
-  const d = await stripe.disputes.retrieve(dispute_id, { stripeAccount: stripe_account_id });
+  const d = await stripeCircuitBreaker(
+    'disputes.retrieve',
+    () => stripe.disputes.retrieve(dispute_id, { stripeAccount: stripe_account_id }),
+    {
+      failureThreshold: 4,
+      cooldownPeriod: 120_000
+    }
+  );
   const tMinus = d.evidence_details?.due_by ? new Date((d.evidence_details.due_by*1000) - (48*3600*1000)).toISOString() : null;
   await upsertCase(stripe_account_id, d, {});
   return { ...evt, dispute: d, merchant, "dispute.evidence_details.due_by_minus_48h": tMinus };

--- a/src/handlers/getPaymentIntent.ts
+++ b/src/handlers/getPaymentIntent.ts
@@ -1,9 +1,17 @@
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from '../shared/circuitBreaker.js';
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
 
 export async function handler(evt:any){
   const { charge, merchant:{stripe_account_id} } = evt;
   if(!charge?.payment_intent) return { ...evt, payment_intent: null };
-  const pi = await stripe.paymentIntents.retrieve(charge.payment_intent as string, { stripeAccount: stripe_account_id });
+  const pi = await stripeCircuitBreaker(
+    'paymentIntents.retrieve',
+    () => stripe.paymentIntents.retrieve(charge.payment_intent as string, { stripeAccount: stripe_account_id }),
+    {
+      failureThreshold: 4,
+      cooldownPeriod: 120_000
+    }
+  );
   return { ...evt, payment_intent: pi };
 }

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { fetchWithCircuitBreaker } from "../shared/circuitBreaker.js";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -33,11 +34,19 @@ export async function handler(event: any) {
       client_secret: process.env.STRIPE_SECRET!
     });
     
-    const response = await fetch('https://connect.stripe.com/oauth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body
-    });
+    const response = await fetchWithCircuitBreaker(
+      'https://connect.stripe.com/oauth/token',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body
+      },
+      {
+        breakerId: 'stripe:oauth.manualRefresh',
+        failureThreshold: 3,
+        cooldownPeriod: 60_000
+      }
+    );
     
     const json: any = await response.json();
     

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -3,6 +3,7 @@ import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 
 const sfn = new SFNClient({});
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
@@ -58,7 +59,14 @@ export async function handler(event: any) {
       stripeOptions = { stripeAccount: merchantId };
     }
     
-    const dispute = await stripe.disputes.retrieve(disputeId, stripeOptions);
+    const dispute = await stripeCircuitBreaker(
+      'disputes.retrieve',
+      () => stripe.disputes.retrieve(disputeId, stripeOptions),
+      {
+        failureThreshold: 4,
+        cooldownPeriod: 120_000
+      }
+    );
     
     // Check if evidence deadline has passed
     if (dispute.evidence_details?.due_by) {

--- a/src/handlers/stripeStageEvidence.ts
+++ b/src/handlers/stripeStageEvidence.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from '../shared/circuitBreaker.js';
 
 export async function handler(evt:any){
   const { dispute, evidence, merchant } = evt;
@@ -19,6 +20,13 @@ export async function handler(evt:any){
     stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
   }
   
-  const res = await stripe.disputes.update(dispute.id, { evidence, submit: false }, stripeOptions);
+  const res = await stripeCircuitBreaker(
+    'disputes.update',
+    () => stripe.disputes.update(dispute.id, { evidence, submit: false }, stripeOptions),
+    {
+      failureThreshold: 3,
+      cooldownPeriod: 120_000
+    }
+  );
   return { ...evt, staged: true, dispute: res };
 }

--- a/src/handlers/stripeSubmitEvidence.ts
+++ b/src/handlers/stripeSubmitEvidence.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from '../shared/circuitBreaker.js';
 
 export async function handler(evt:any){
   const { dispute, merchant } = evt;
@@ -19,6 +20,13 @@ export async function handler(evt:any){
     stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
   }
   
-  const res = await stripe.disputes.update(dispute.id, { submit: true }, stripeOptions);
+  const res = await stripeCircuitBreaker(
+    'disputes.update',
+    () => stripe.disputes.update(dispute.id, { submit: true }, stripeOptions),
+    {
+      failureThreshold: 3,
+      cooldownPeriod: 120_000
+    }
+  );
   return { submitted: true, dispute: res };
 }

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -2,6 +2,7 @@ import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 import { 
   predictWinRate, 
   shouldSubmit,
@@ -76,9 +77,17 @@ export async function handler(event:any){
 
   try {
     // Get dispute details with charge expanded
-    const dispute = await stripe.disputes.retrieve(id, 
-      { expand: ['charge'] },
-      { stripeAccount: merchantId }
+    const dispute = await stripeCircuitBreaker(
+      'disputes.retrieve',
+      () => stripe.disputes.retrieve(
+        id,
+        { expand: ['charge'] },
+        { stripeAccount: merchantId }
+      ),
+      {
+        failureThreshold: 4,
+        cooldownPeriod: 120_000
+      }
     );
     const charge = dispute.charge as Stripe.Charge;
     
@@ -220,7 +229,14 @@ export async function handler(event:any){
     
     // Submit the dispute
     console.log(`[SUBMIT] Submitting dispute ${id} for merchant ${merchantId}`);
-    const res = await stripe.disputes.update(id, { submit: true }, { stripeAccount: merchantId });
+    const res = await stripeCircuitBreaker(
+      'disputes.update',
+      () => stripe.disputes.update(id, { submit: true }, { stripeAccount: merchantId }),
+      {
+        failureThreshold: 4,
+        cooldownPeriod: 120_000
+      }
+    );
     
     // Audit successful submission
     await createAuditLog({

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -3,6 +3,7 @@ import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
 import Stripe from 'stripe';
+import { stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
@@ -244,9 +245,16 @@ export async function getSubscriptionStatus(event: any) {
     let stripeSubscription = null;
     if (merchant?.subscription_id) {
       try {
-        stripeSubscription = await stripe.subscriptions.retrieve(
-          merchant.subscription_id,
-          { expand: ['customer', 'default_payment_method'] }
+        stripeSubscription = await stripeCircuitBreaker(
+          'subscriptions.retrieve',
+          () => stripe.subscriptions.retrieve(
+            merchant.subscription_id,
+            { expand: ['customer', 'default_payment_method'] }
+          ),
+          {
+            failureThreshold: 4,
+            cooldownPeriod: 90_000
+          }
         );
       } catch (e) {
         console.error('Error fetching Stripe subscription:', e);
@@ -321,9 +329,16 @@ export async function cancelSubscription(event: any) {
     }
     
     // Cancel subscription at period end
-    const canceledSubscription = await stripe.subscriptions.update(
-      merchant.subscription_id,
-      { cancel_at_period_end: true }
+    const canceledSubscription = await stripeCircuitBreaker(
+      'subscriptions.update',
+      () => stripe.subscriptions.update(
+        merchant.subscription_id,
+        { cancel_at_period_end: true }
+      ),
+      {
+        failureThreshold: 4,
+        cooldownPeriod: 90_000
+      }
     );
     
     // Update merchant record

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -5,6 +5,7 @@ import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
 import { getMerchantWebhookSecret, validateWebhookSignature } from "../shared/webhookSecrets.js";
+import { stripeCircuitBreaker } from "../shared/circuitBreaker.js";
 import { 
   analyzeDispute, 
   quickAssessRisk,
@@ -315,7 +316,14 @@ export async function handler(event:any){
       if(evt.type === 'charge.dispute.created'){
         try {
           // Get charge data for analysis
-          const charge = await stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount });
+          const charge = await stripeCircuitBreaker(
+            'charges.retrieve',
+            () => stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount }),
+            {
+              failureThreshold: 4,
+              cooldownPeriod: 120_000
+            }
+          );
           
           // Quick risk assessment first
           riskLevel = quickAssessRisk(dispute);
@@ -450,7 +458,14 @@ export async function handler(event:any){
         // 6. Update pattern cache with outcome (Safe - with fallback)
         if (patternCache && process.env.ENABLE_PATTERN_CACHE === 'true') {
           try {
-            const charge = await stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount });
+            const charge = await stripeCircuitBreaker(
+              'charges.retrieve',
+              () => stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount }),
+              {
+                failureThreshold: 4,
+                cooldownPeriod: 120_000
+              }
+            );
             const patternKey = {
               amount: charge?.amount || 0,
               reason: dispute?.reason || 'unknown',

--- a/src/shared/circuitBreaker.ts
+++ b/src/shared/circuitBreaker.ts
@@ -1,0 +1,205 @@
+export type CircuitBreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+export interface CircuitBreakerOptions {
+  /** Number of consecutive failures before tripping the breaker */
+  failureThreshold: number;
+  /** Number of consecutive successes in half-open state to close the breaker */
+  successThreshold: number;
+  /** How long to wait before allowing another try after tripping (ms) */
+  cooldownPeriod: number;
+  /** Timeout for the protected action (ms) */
+  timeout: number;
+  /** Maximum number of concurrent calls allowed while half-open */
+  halfOpenMaxCalls?: number;
+}
+
+const DEFAULT_OPTIONS: CircuitBreakerOptions = {
+  failureThreshold: 5,
+  successThreshold: 1,
+  cooldownPeriod: 30_000,
+  timeout: 10_000,
+  halfOpenMaxCalls: 1,
+};
+
+export class CircuitBreakerOpenError extends Error {
+  public readonly nextAttempt: number;
+  constructor(message: string, nextAttempt: number) {
+    super(message);
+    this.name = 'CircuitBreakerOpenError';
+    this.nextAttempt = nextAttempt;
+  }
+}
+
+export class CircuitBreakerTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CircuitBreakerTimeoutError';
+  }
+}
+
+export class CircuitBreaker {
+  private state: CircuitBreakerState = 'CLOSED';
+  private failureCount = 0;
+  private successCount = 0;
+  private nextAttempt = 0;
+  private activeHalfOpenCalls = 0;
+  private options: CircuitBreakerOptions;
+
+  constructor(private readonly name: string, options?: Partial<CircuitBreakerOptions>) {
+    this.options = { ...DEFAULT_OPTIONS, ...(options ?? {}) };
+  }
+
+  updateOptions(options: Partial<CircuitBreakerOptions>) {
+    this.options = { ...this.options, ...options };
+  }
+
+  async execute<T>(action: () => Promise<T>): Promise<T> {
+    if (this.state === 'OPEN') {
+      if (Date.now() >= this.nextAttempt) {
+        this.state = 'HALF_OPEN';
+        this.successCount = 0;
+        this.activeHalfOpenCalls = 0;
+      } else {
+        throw new CircuitBreakerOpenError(
+          `Circuit breaker \"${this.name}\" is open until ${new Date(this.nextAttempt).toISOString()}`,
+          this.nextAttempt
+        );
+      }
+    }
+
+    if (this.state === 'HALF_OPEN') {
+      const maxCalls = this.options.halfOpenMaxCalls ?? 1;
+      if (this.activeHalfOpenCalls >= maxCalls) {
+        throw new CircuitBreakerOpenError(
+          `Circuit breaker \"${this.name}\" is half-open and only allows ${maxCalls} concurrent call(s)`,
+          this.nextAttempt
+        );
+      }
+      this.activeHalfOpenCalls++;
+    }
+
+    const timeout = this.options.timeout;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+
+    const timeoutPromise = timeout > 0
+      ? new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(() => {
+            reject(new CircuitBreakerTimeoutError(`Circuit breaker \"${this.name}\" timed out after ${timeout}ms`));
+          }, timeout);
+        })
+      : null;
+
+    try {
+      const actionPromise = action();
+      const result = timeoutPromise
+        ? await Promise.race([actionPromise, timeoutPromise])
+        : await actionPromise;
+      this.onSuccess();
+      return result as T;
+    } catch (error) {
+      this.onFailure(error as Error);
+      throw error;
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      if (this.state === 'HALF_OPEN' && this.activeHalfOpenCalls > 0) {
+        this.activeHalfOpenCalls--;
+      }
+    }
+  }
+
+  private onSuccess() {
+    if (this.state === 'HALF_OPEN') {
+      this.successCount++;
+      if (this.successCount >= this.options.successThreshold) {
+        this.close();
+      }
+    } else {
+      this.reset();
+    }
+  }
+
+  private onFailure(error: Error) {
+    console.warn(`Circuit breaker \"${this.name}\" caught error: ${error.message}`);
+    if (this.state === 'HALF_OPEN') {
+      this.trip();
+      return;
+    }
+
+    this.failureCount++;
+    if (this.failureCount >= this.options.failureThreshold) {
+      this.trip();
+    }
+  }
+
+  private trip() {
+    this.state = 'OPEN';
+    this.nextAttempt = Date.now() + this.options.cooldownPeriod;
+    this.failureCount = 0;
+    this.successCount = 0;
+    this.activeHalfOpenCalls = 0;
+    console.warn(`Circuit breaker \"${this.name}\" opened. Next attempt after ${new Date(this.nextAttempt).toISOString()}`);
+  }
+
+  private close() {
+    console.info(`Circuit breaker \"${this.name}\" closed after successful calls.`);
+    this.reset();
+  }
+
+  private reset() {
+    this.state = 'CLOSED';
+    this.failureCount = 0;
+    this.successCount = 0;
+    this.activeHalfOpenCalls = 0;
+  }
+}
+
+const breakers = new Map<string, CircuitBreaker>();
+
+export function getCircuitBreaker(name: string, options?: Partial<CircuitBreakerOptions>): CircuitBreaker {
+  let breaker = breakers.get(name);
+  if (!breaker) {
+    breaker = new CircuitBreaker(name, options);
+    breakers.set(name, breaker);
+  } else if (options) {
+    breaker.updateOptions(options);
+  }
+  return breaker;
+}
+
+export async function withCircuitBreaker<T>(
+  name: string,
+  action: () => Promise<T>,
+  options?: Partial<CircuitBreakerOptions>
+): Promise<T> {
+  const breaker = getCircuitBreaker(name, options);
+  return breaker.execute(action);
+}
+
+export interface FetchCircuitBreakerOptions extends Partial<CircuitBreakerOptions> {
+  breakerId?: string;
+}
+
+export function fetchWithCircuitBreaker(
+  url: string | URL,
+  init?: RequestInit,
+  options?: FetchCircuitBreakerOptions
+): Promise<Response> {
+  const targetUrl = typeof url === 'string' ? new URL(url) : url;
+  const { breakerId, ...breakerOptions } = options ?? {};
+
+  return withCircuitBreaker(
+    breakerId ?? `fetch:${targetUrl.hostname}`,
+    () => fetch(url, init),
+    { timeout: 15_000, ...breakerOptions }
+  );
+}
+
+export function stripeCircuitBreaker<T>(
+  operation: string,
+  action: () => Promise<T>,
+  options?: Partial<CircuitBreakerOptions>
+): Promise<T> {
+  return withCircuitBreaker(`stripe:${operation}`, action, { timeout: 20_000, ...options });
+}


### PR DESCRIPTION
## Summary
- add a reusable circuit breaker utility with helpers for fetch and Stripe API calls
- wrap Stripe OAuth token refresh and checkout flows with circuit breaker protection
- guard Stripe dispute lifecycle handlers with circuit breaker calls and update evidence package typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deeac9ac34832f8c37398aa2030dc6