### PR TITLE
Add structured logging for evidence processing

### DIFF
--- a/src/handlers/buildEvidence.ts
+++ b/src/handlers/buildEvidence.ts
@@ -8,6 +8,9 @@ import {
 import { CloudWatch, StandardUnit } from '@aws-sdk/client-cloudwatch';
 import { ddb } from "../shared/ddb";
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { getLogger, errorToMetadata } from '../shared/logger.js';
+
+const logger = getLogger('handlers.buildEvidence');
 
 // ML Enhancement Imports (Safe - with fallbacks)
 let patternCache: any = null;
@@ -18,27 +21,27 @@ let fraudTracker: any = null;
 if (process.env.ENABLE_PATTERN_CACHE === 'true') {
   try {
     patternCache = require('../cache/patternCache').patternCache;
-    console.log('✅ Pattern cache ML enabled');
+    logger.info('Pattern cache ML enabled');
   } catch (e) {
-    console.log('Pattern cache not available, using standard flow');
+    logger.warn('Pattern cache not available, using standard flow', errorToMetadata(e));
   }
 }
 
 if (process.env.ENABLE_SCORE_CACHE === 'true') {
   try {
     scoreCache = require('../cache/scoreCache').scoreCache;
-    console.log('✅ Score cache ML enabled');
+    logger.info('Score cache ML enabled');
   } catch (e) {
-    console.log('Score cache not available, using standard flow');
+    logger.warn('Score cache not available, using standard flow', errorToMetadata(e));
   }
 }
 
 if (process.env.ENABLE_FRAUD_ML === 'true') {
   try {
     fraudTracker = require('../cache/fraudTracker').fraudTracker;
-    console.log('✅ Fraud ML detection enabled');
+    logger.info('Fraud ML detection enabled');
   } catch (e) {
-    console.log('Fraud ML not available, using standard flow');
+    logger.warn('Fraud ML not available, using standard flow', errorToMetadata(e));
   }
 }
 
@@ -57,7 +60,7 @@ async function publishMetric(name: string, value: number, unit: string = 'Count'
       }]
     });
   } catch (error) {
-    console.error('Failed to publish metric:', name, error);
+    logger.error('Failed to publish metric', errorToMetadata(error, { metricName: name }));
   }
 }
 
@@ -67,7 +70,7 @@ export async function handler(evt:any){
   // Use merchant's OAuth token for connected accounts, fallback to global secret
   const stripeKey = merchant?.access_token || process.env.STRIPE_SECRET || '';
   if (!stripeKey) {
-    console.error('No Stripe key available for merchant:', merchant?.id);
+    logger.error('No Stripe key available for merchant', { merchantId: merchant?.id });
     throw new Error('Missing Stripe authentication for merchant');
   }
   
@@ -96,17 +99,28 @@ export async function handler(evt:any){
       const cachedPattern = await patternCache.lookup(patternKey);
       if (cachedPattern && cachedPattern.confidence > 0.8) {
         cachedWinProbability = cachedPattern.winRate;
-        console.log(`⚡ ML Pattern Cache Hit: ${(cachedWinProbability * 100).toFixed(1)}% win probability (confidence: ${cachedPattern.confidence})`);
+        logger.info('Pattern cache hit', {
+          disputeId: dispute?.id,
+          winProbability: cachedWinProbability,
+          confidence: cachedPattern.confidence,
+          patternKey
+        });
         await publishMetric('ml_pattern_cache_hit', 1);
-        
+
         // Early exit if win probability too low
         if (cachedWinProbability < 0.20) {
-          console.log('🛑 ML: Very low win probability, minimal evidence mode');
+          logger.warn('Very low win probability, switching to minimal evidence mode', {
+            disputeId: dispute?.id,
+            winProbability: cachedWinProbability
+          });
           await publishMetric('ml_early_exit_low_probability', 1);
         }
       }
     } catch (error) {
-      console.log('Pattern cache lookup failed, continuing with standard flow:', error);
+      logger.warn('Pattern cache lookup failed, continuing with standard flow', errorToMetadata(error, {
+        disputeId: dispute?.id,
+        merchantId: merchant?.id
+      }));
       await publishMetric('ml_pattern_cache_error', 1);
     }
   }
@@ -125,11 +139,18 @@ export async function handler(evt:any){
       const fraudScore = await fraudTracker.analyze(fraudSignals);
       if (fraudScore > 0.85) {
         fraudDetected = true;
-        console.log(`🚨 ML Fraud Detection: High fraud probability (${(fraudScore * 100).toFixed(1)}%)`);
+        logger.warn('Fraud detection high risk score', {
+          disputeId: dispute?.id,
+          fraudScore,
+          fraudSignals
+        });
         await publishMetric('ml_fraud_detected', 1);
       }
     } catch (error) {
-      console.log('Fraud detection failed, continuing without fraud signals:', error);
+      logger.warn('Fraud detection failed, continuing without fraud signals', errorToMetadata(error, {
+        disputeId: dispute?.id,
+        merchantId: merchant?.id
+      }));
       await publishMetric('ml_fraud_detection_error', 1);
     }
   }
@@ -150,10 +171,13 @@ export async function handler(evt:any){
       try {
         // Use cached win probability or calculate new one
         const winProbability = cachedWinProbability || evidencePackage?.winProbability || 0.5;
-        
+
         // Optimize evidence based on win probability
         if (winProbability > 0.75) {
-          console.log(`🚀 ML: High win probability (${(winProbability * 100).toFixed(1)}%), using aggressive evidence strategy`);
+          logger.info('Applying aggressive evidence strategy', {
+            disputeId: dispute?.id,
+            winProbability
+          });
           mlOptimizedEvidence = {
             strategy: 'aggressive',
             emphasizeCE3: true,
@@ -162,7 +186,10 @@ export async function handler(evt:any){
           };
           await publishMetric('ml_strategy_aggressive', 1);
         } else if (winProbability > 0.45) {
-          console.log(`⚡ ML: Medium win probability (${(winProbability * 100).toFixed(1)}%), using balanced evidence strategy`);
+          logger.info('Applying balanced evidence strategy', {
+            disputeId: dispute?.id,
+            winProbability
+          });
           mlOptimizedEvidence = {
             strategy: 'balanced',
             emphasizeCE3: evidencePackage.ce3Eligible,
@@ -171,7 +198,10 @@ export async function handler(evt:any){
           };
           await publishMetric('ml_strategy_balanced', 1);
         } else {
-          console.log(`⚠️ ML: Low win probability (${(winProbability * 100).toFixed(1)}%), using defensive evidence strategy`);
+          logger.warn('Applying defensive evidence strategy', {
+            disputeId: dispute?.id,
+            winProbability
+          });
           mlOptimizedEvidence = {
             strategy: 'defensive',
             emphasizeCE3: false,
@@ -196,15 +226,21 @@ export async function handler(evt:any){
         });
         
       } catch (error) {
-        console.log('Score cache optimization failed, using standard strategy:', error);
+        logger.warn('Score cache optimization failed, using standard strategy', errorToMetadata(error, {
+          disputeId: dispute?.id,
+          merchantId: merchant?.id
+        }));
         await publishMetric('ml_score_cache_error', 1);
       }
     }
-    
+
     // Apply ML optimizations if available
     if (mlOptimizedEvidence && fraudDetected) {
-      console.log('🚨 ML: Fraud detected, adding extra verification evidence');
-      evidencePackage.fraudWarning = true;
+      logger.warn('Fraud detected - augmenting evidence package', {
+        disputeId: dispute?.id,
+        fraudDetected
+      });
+      (evidencePackage as any).fraudWarning = true;
     }
     
     // Extract the evidence object for Stripe submission
@@ -253,10 +289,13 @@ export async function handler(evt:any){
           // Add narrative to evidence
           evidence.customer_communication = aiNarrative;
           evidencePackage.narrative = aiNarrative;
-          
+
           // Track metrics
           const wordCount = aiNarrative.split(/\s+/).length;
-          console.log('[AI] Narrative generated:', wordCount, 'words');
+          logger.info('AI narrative generated', {
+            disputeId: dispute.id,
+            wordCount
+          });
           await publishMetric('ai_narrative_generated', 1);
           await publishMetric('ai_narrative_words', wordCount, 'None');
         }
@@ -283,17 +322,21 @@ export async function handler(evt:any){
             evidence.duplicate_charge_explanation = evidence.duplicate_charge_explanation || ceInfo;
           }
           
-          console.log('[AI] Evidence bundle collected:', {
+          logger.info('AI evidence bundle collected', {
+            disputeId: dispute.id,
             ceCandidates: aiBundle.ceCandidates.length,
-            hasShipping: !!aiBundle.shipping,
-            hasCommunications: !!aiBundle.communications,
-            hasUsageSignals: !!aiBundle.usageSignals
+            hasShipping: Boolean(aiBundle.shipping),
+            hasCommunications: Boolean(aiBundle.communications),
+            hasUsageSignals: Boolean(aiBundle.usageSignals)
           });
-          
+
           await publishMetric('ai_evidence_collected', 1);
         }
       } catch (error) {
-        console.error('[AI] Evidence collection/narrative generation failed:', error);
+        logger.error('Evidence collection or narrative generation failed', errorToMetadata(error, {
+          disputeId: dispute?.id,
+          merchantId: merchant?.id
+        }));
         await publishMetric('ai_error', 1);
       }
     }
@@ -317,9 +360,16 @@ export async function handler(evt:any){
             ttl: Math.floor(Date.now() / 1000) + (90 * 24 * 60 * 60) // 90 days TTL
           }
         }));
-        console.log(`📊 ML: Stored prediction for dispute ${dispute.id}: ${(evidencePackage.winProbability * 100).toFixed(1)}%`);
+        logger.info('Stored ML prediction', {
+          disputeId: dispute.id,
+          merchantId: merchant?.stripe_account_id,
+          winProbability: evidencePackage.winProbability
+        });
       } catch (error) {
-        console.error('Failed to store ML prediction:', error);
+        logger.error('Failed to store ML prediction', errorToMetadata(error, {
+          disputeId: dispute?.id,
+          merchantId: merchant?.stripe_account_id
+        }));
       }
     }
     
@@ -344,7 +394,10 @@ export async function handler(evt:any){
     };
     
   } catch (error) {
-    console.error('Error in advanced evidence bundler, falling back to basic:', error);
+    logger.error('Advanced evidence bundler failed, falling back to basic evidence', errorToMetadata(error, {
+      disputeId: dispute?.id,
+      merchantId: merchant?.id
+    }));
     
     // Fallback to basic evidence if advanced bundler fails
     const customer_name = charge?.billing_details?.name || payment_intent?.shipping?.name || '';

--- a/src/shared/db-helpers.ts
+++ b/src/shared/db-helpers.ts
@@ -5,10 +5,12 @@
 
 import { ddb } from "./ddb.js";
 import { QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { getLogger, errorToMetadata } from "./logger.js";
 
 const CASES = process.env.CASES_TABLE!;
 const MERCHANTS = process.env.MERCHANTS_TABLE!;
 const SUBMISSIONS = process.env.SUBMISSIONS_TABLE!;
+const logger = getLogger('shared.dbHelpers');
 
 /**
  * Calculate REAL merchant win rate from historical cases
@@ -42,10 +44,16 @@ export async function getMerchantWinRate(merchantId: string, daysPeriod = 180): 
     const wins = items.filter(item => item.dispute_status === "won").length;
     const winRate = wins / items.length;
     
-    console.log(`[DB] Merchant ${merchantId} win rate: ${(winRate * 100).toFixed(1)}% (${wins}/${items.length} cases)`);
+    logger.info('Merchant win rate calculated', {
+      merchantId,
+      winRate,
+      wins,
+      totalCases: items.length,
+      daysPeriod
+    });
     return winRate;
   } catch (error) {
-    console.error('[DB] Error calculating merchant win rate:', error);
+    logger.error('Error calculating merchant win rate', errorToMetadata(error, { merchantId, daysPeriod }));
     return 0.5; // Default to neutral on error
   }
 }
@@ -69,10 +77,10 @@ export async function getCustomerTransactionCount(merchantId: string, customerId
     }));
     
     const count = response.Items?.length || 0;
-    console.log(`[DB] Customer ${customerId} has ${count} prior transactions`);
+    logger.info('Customer prior transactions retrieved', { merchantId, customerId, count });
     return count;
   } catch (error) {
-    console.error('[DB] Error getting customer transaction count:', error);
+    logger.error('Error getting customer transaction count', errorToMetadata(error, { merchantId, customerId }));
     return 0;
   }
 }
@@ -105,10 +113,10 @@ export async function getCustomerTenureDays(merchantId: string, customerId: stri
     const earliestTimestamp = Math.min(...items.map(item => item.created_at_epoch || Date.now() / 1000));
     const tenureDays = Math.floor((Date.now() / 1000 - earliestTimestamp) / (24 * 60 * 60));
     
-    console.log(`[DB] Customer ${customerId} tenure: ${tenureDays} days`);
+    logger.info('Customer tenure calculated', { merchantId, customerId, tenureDays });
     return tenureDays;
   } catch (error) {
-    console.error('[DB] Error calculating customer tenure:', error);
+    logger.error('Error calculating customer tenure', errorToMetadata(error, { merchantId, customerId }));
     return 0;
   }
 }
@@ -133,10 +141,10 @@ export async function getCustomerOrderCount(merchantId: string, customerId: stri
     }));
     
     const count = response.Items?.length || 0;
-    console.log(`[DB] Customer ${customerId} has ${count} orders`);
+    logger.info('Customer order count retrieved', { merchantId, customerId, count });
     return count;
   } catch (error) {
-    console.error('[DB] Error getting customer order count:', error);
+    logger.error('Error getting customer order count', errorToMetadata(error, { merchantId, customerId }));
     return 0;
   }
 }
@@ -164,10 +172,15 @@ export async function getCustomerRefundsLast90Days(merchantId: string, customerI
     }));
     
     const count = response.Items?.length || 0;
-    console.log(`[DB] Customer ${customerId} has ${count} refunds in last 90 days`);
+    logger.info('Customer refunds retrieved for trailing window', {
+      merchantId,
+      customerId,
+      count,
+      windowDays: 90
+    });
     return count;
   } catch (error) {
-    console.error('[DB] Error getting customer refunds:', error);
+    logger.error('Error getting customer refunds', errorToMetadata(error, { merchantId, customerId }));
     return 0;
   }
 }
@@ -215,15 +228,21 @@ export async function checkCE3Eligibility(
       }
     }
     
-    console.log(`[DB] CE3.0 eligibility for ${customerId}: ${eligible} (${priorTransactions.length} prior transactions)`);
-    
+    logger.info('Computed CE3 eligibility', {
+      merchantId,
+      customerId,
+      eligible,
+      priorTransactionCount: priorTransactions.length,
+      matchedElements
+    });
+
     return {
       eligible,
       priorTransactionCount: priorTransactions.length,
       matchedElements
     };
   } catch (error) {
-    console.error('[DB] Error checking CE3 eligibility:', error);
+    logger.error('Error checking CE3 eligibility', errorToMetadata(error, { merchantId, customerId, chargeId }));
     return { eligible: false, priorTransactionCount: 0, matchedElements: [] };
   }
 }

--- a/src/shared/ddb.ts
+++ b/src/shared/ddb.ts
@@ -1,3 +1,4 @@
+import "./logger.js";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,0 +1,182 @@
+import { createLogger, format, transports, Logger } from 'winston';
+import util from 'util';
+
+const DEFAULT_SERVICE_NAME = process.env.LOG_SERVICE_NAME || 'stripe-chargeback-autopilot';
+const DEFAULT_LEVEL = process.env.LOG_LEVEL || (process.env.NODE_ENV === 'production' ? 'info' : 'debug');
+
+const flattenMetadata = format((info) => {
+  if (info.metadata && typeof info.metadata === 'object') {
+    Object.assign(info, info.metadata);
+    delete info.metadata;
+  }
+  return info;
+});
+
+const baseLogger = createLogger({
+  level: DEFAULT_LEVEL,
+  defaultMeta: { service: DEFAULT_SERVICE_NAME },
+  format: format.combine(
+    format.timestamp(),
+    format.errors({ stack: true }),
+    format.metadata({ fillExcept: ['level', 'message', 'timestamp', 'service'] }),
+    flattenMetadata(),
+    format.json()
+  ),
+  transports: [
+    new transports.Console({ handleExceptions: true })
+  ],
+  exitOnError: false
+});
+
+type ConsoleMethod = 'log' | 'info' | 'warn' | 'error' | 'debug';
+
+const consoleLevelMap: Record<ConsoleMethod, string> = {
+  log: 'info',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+  debug: 'debug'
+};
+
+function getCallSite(): { file?: string; line?: number; column?: number } | undefined {
+  const stack = new Error().stack;
+  if (!stack) {
+    return undefined;
+  }
+
+  const frames = stack.split('\n').slice(3);
+  for (const frame of frames) {
+    const cleaned = frame.trim();
+    if (!cleaned || cleaned.includes('shared/logger')) {
+      continue;
+    }
+
+    const match = cleaned.match(/\(?([^():]+):(\d+):(\d+)\)?$/);
+    if (match) {
+      return {
+        file: match[1],
+        line: Number.parseInt(match[2], 10),
+        column: Number.parseInt(match[3], 10)
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const serialized: Record<string, unknown> = {
+      message: error.message,
+      name: error.name,
+      stack: error.stack
+    };
+
+    const props = Object.getOwnPropertyNames(error);
+    for (const key of props) {
+      if (!(key in serialized)) {
+        serialized[key] = (error as any)[key];
+      }
+    }
+
+    return serialized;
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    return error as Record<string, unknown>;
+  }
+
+  return { value: error };
+}
+
+function normaliseLogArguments(args: unknown[]): { message: string; meta?: Record<string, unknown> } {
+  if (args.length === 0) {
+    return { message: '' };
+  }
+
+  const message = typeof args[0] === 'string'
+    ? util.format(args[0] as string, ...args.slice(1))
+    : util.format(...(args as [unknown, ...unknown[]]));
+
+  const context: unknown[] = [];
+  const errors: unknown[] = [];
+
+  args.forEach((arg, index) => {
+    if (arg instanceof Error) {
+      errors.push(arg);
+      return;
+    }
+
+    if (typeof arg === 'string' && index === 0) {
+      return;
+    }
+
+    context.push(arg);
+  });
+
+  const meta: Record<string, unknown> = {};
+
+  if (errors.length > 0) {
+    meta.errors = errors.map(serializeError);
+  }
+
+  if (context.length === 1) {
+    meta.context = context[0];
+  } else if (context.length > 1) {
+    meta.context = context;
+  }
+
+  const callSite = getCallSite();
+  if (callSite) {
+    meta.source = callSite;
+  }
+
+  if (Object.keys(meta).length === 0) {
+    return { message };
+  }
+
+  return { message, meta };
+}
+
+function attachStructuredConsole(loggerInstance: Logger) {
+  const globalKey = Symbol.for('stripe-ultrathink.logger.initialised');
+  if ((globalThis as any)[globalKey]) {
+    return;
+  }
+
+  const originalConsole: Partial<Record<ConsoleMethod, (...args: unknown[]) => void>> = {};
+
+  (Object.keys(consoleLevelMap) as ConsoleMethod[]).forEach((method) => {
+    originalConsole[method] = console[method].bind(console);
+
+    console[method] = ((...args: unknown[]) => {
+      const { message, meta } = normaliseLogArguments(args);
+      const level = consoleLevelMap[method];
+      const payload = meta ? { ...meta, level, message } : { level, message };
+      loggerInstance.log(payload);
+    }) as typeof console[typeof method];
+  });
+
+  Object.defineProperty(globalThis, globalKey, {
+    value: true,
+    configurable: false,
+    enumerable: false,
+    writable: false
+  });
+}
+
+attachStructuredConsole(baseLogger);
+
+export function getLogger(module: string, defaultMeta: Record<string, unknown> = {}) {
+  return baseLogger.child({ module, ...defaultMeta });
+}
+
+export function errorToMetadata(error: unknown, additional: Record<string, unknown> = {}) {
+  if (!error) {
+    return { ...additional, error: { message: 'Unknown error' } };
+  }
+
+  return { ...additional, error: serializeError(error) };
+}
+
+export { baseLogger as logger };

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -1,4 +1,7 @@
 import { createErrorResponse } from './responses.js';
+import { getLogger } from './logger.js';
+
+const logger = getLogger('shared.validation');
 
 // Input validation rules
 export interface ValidationRule {
@@ -205,7 +208,10 @@ export function validateInput(data: any, schema: ValidationSchema): {
   const unexpectedKeys = dataKeys.filter(key => !schemaKeys.includes(key));
   
   if (unexpectedKeys.length > 0) {
-    console.warn('Unexpected fields in input:', unexpectedKeys);
+    logger.warn('Unexpected fields detected during validation', {
+      unexpectedKeys,
+      allowedKeys: schemaKeys
+    });
     // Don't include unexpected fields in sanitized output
   }
   

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,12 +1,14 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { getLogger, errorToMetadata } from './logger.js';
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
 const ssm = new SSMClient({});
 
 const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE || 'MerchantsTable';
+const logger = getLogger('shared.webhookSecrets');
 
 /**
  * Get the webhook secret for a specific merchant account
@@ -23,7 +25,7 @@ export async function getMerchantWebhookSecret(merchantId: string): Promise<stri
     }));
     
     if (result.Item?.webhook_secret) {
-      console.log(`[WEBHOOK] Using merchant-specific webhook secret for ${merchantId}`);
+      logger.info('Using merchant-specific webhook secret', { merchantId });
       return result.Item.webhook_secret;
     }
     
@@ -31,10 +33,10 @@ export async function getMerchantWebhookSecret(merchantId: string): Promise<stri
     if (result.Item?.webhook_endpoint_id) {
       // For Connect webhooks, the secret follows a pattern
       // but we should have stored it during webhook registration
-      console.log(`[WEBHOOK] Found webhook endpoint ID but no secret for ${merchantId}`);
+      logger.warn('Found webhook endpoint ID but no secret', { merchantId });
     }
   } catch (error) {
-    console.error(`[WEBHOOK] Error fetching merchant webhook secret:`, error);
+    logger.error('Error fetching merchant webhook secret', errorToMetadata(error, { merchantId }));
   }
   
   // Fallback to global webhook secret from environment/SSM
@@ -47,7 +49,7 @@ export async function getMerchantWebhookSecret(merchantId: string): Promise<stri
 async function getGlobalWebhookSecret(): Promise<string> {
   // First check environment variable
   if (process.env.STRIPE_CONNECT_WEBHOOK_SECRET) {
-    console.log('[WEBHOOK] Using global webhook secret from environment');
+    logger.info('Using global webhook secret from environment');
     return process.env.STRIPE_CONNECT_WEBHOOK_SECRET;
   }
   
@@ -59,15 +61,15 @@ async function getGlobalWebhookSecret(): Promise<string> {
     }));
     
     if (result.Parameter?.Value) {
-      console.log('[WEBHOOK] Using global webhook secret from SSM');
+      logger.info('Using global webhook secret from SSM');
       return result.Parameter.Value;
     }
   } catch (error) {
-    console.error('[WEBHOOK] Error fetching webhook secret from SSM:', error);
+    logger.error('Error fetching webhook secret from SSM', errorToMetadata(error));
   }
-  
+
   // Last resort fallback - should not happen in production
-  console.error('[WEBHOOK] WARNING: No webhook secret found, webhooks will fail validation!');
+  logger.error('No webhook secret found, webhooks will fail validation');
   throw new Error('No webhook secret configured');
 }
 
@@ -98,10 +100,10 @@ export async function validateWebhookSignature(
       webhookSecret
     );
     
-    console.log(`[WEBHOOK] Signature validated for event ${event.id}`);
+    logger.info('Signature validated for event', { eventId: event.id, accountId });
     return true;
   } catch (error) {
-    console.error('[WEBHOOK] Signature validation failed:', error);
+    logger.error('Signature validation failed', errorToMetadata(error, { accountId }));
     return false;
   }
 }
@@ -133,9 +135,9 @@ export async function storeWebhookSecret(
       }
     }));
     
-    console.log(`[WEBHOOK] Stored webhook secret for merchant ${merchantId}`);
+    logger.info('Stored webhook secret for merchant', { merchantId, hasEndpoint: Boolean(webhookEndpointId) });
   } catch (error) {
-    console.error('[WEBHOOK] Error storing webhook secret:', error);
+    logger.error('Error storing webhook secret', errorToMetadata(error, { merchantId }));
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- add a shared structured logger that emits JSON-formatted output and redirects Console usage
- hook the logger into DynamoDB bootstrap to ensure initialization and instrument shared helpers and webhook secret management
- refactor the evidence builder handler to use contextual log fields for ML and AI decision points

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deeb1e0044832f964eed934185c063