### PR TITLE
Add Lambda timeout guard and graceful shutdown

### DIFF
--- a/src/cache/redisConnection.ts
+++ b/src/cache/redisConnection.ts
@@ -4,6 +4,7 @@
  */
 
 import Redis from 'ioredis';
+import { registerCleanupHandler, type CleanupContext } from '../shared/lambdaLifecycle';
 
 class RedisConnectionManager {
   private static instance: RedisConnectionManager;
@@ -11,8 +12,11 @@ class RedisConnectionManager {
   private connectionPromise: Promise<Redis> | null = null;
   private isConnecting = false;
   private isConnected = false;
+  private shutdownRegistered = false;
 
-  private constructor() {}
+  private constructor() {
+    this.registerShutdownHandler();
+  }
 
   static getInstance(): RedisConnectionManager {
     if (!RedisConnectionManager.instance) {
@@ -50,9 +54,9 @@ class RedisConnectionManager {
 
   private async connect(): Promise<Redis> {
     const REDIS_URL = process.env.REDIS_URL || 'redis://stripedshield-redis.mot6cw.0001.use1.cache.amazonaws.com:6379';
-    
+
     console.log('🔄 Connecting to Redis:', REDIS_URL.replace(/\/\/.*@/, '//***@'));
-    
+
     this.client = new Redis(REDIS_URL, {
       lazyConnect: false, // Connect immediately
       enableReadyCheck: true,
@@ -122,13 +126,50 @@ class RedisConnectionManager {
     return this.client;
   }
 
+  private registerShutdownHandler(): void {
+    if (this.shutdownRegistered) {
+      return;
+    }
+
+    registerCleanupHandler(async (context) => {
+      if (!this.client || !this.isConnected) {
+        return;
+      }
+
+      console.warn(`🛑 Gracefully closing Redis connection due to ${formatCleanupReason(context)}`);
+
+      try {
+        await this.client.quit();
+      } catch (error) {
+        console.error('Error during Redis shutdown:', (error as Error)?.message || error);
+      } finally {
+        this.resetState();
+      }
+    });
+
+    this.shutdownRegistered = true;
+  }
+
+  private resetState(): void {
+    if (this.client) {
+      this.client.removeAllListeners();
+    }
+
+    this.client = null;
+    this.isConnected = false;
+    this.isConnecting = false;
+    this.connectionPromise = null;
+  }
+
   async disconnect(): Promise<void> {
     if (this.client) {
-      await this.client.quit();
-      this.client = null;
-      this.isConnected = false;
-      this.isConnecting = false;
-      this.connectionPromise = null;
+      try {
+        await this.client.quit();
+      } catch (error) {
+        console.error('Error closing Redis connection:', (error as Error)?.message || error);
+      } finally {
+        this.resetState();
+      }
     }
   }
 
@@ -164,3 +205,15 @@ export function isRedisReady(): boolean {
 export async function closeRedisConnection(): Promise<void> {
   await redisManager.disconnect();
 }
+
+function formatCleanupReason(context: CleanupContext): string {
+  switch (context.type) {
+    case 'timeout':
+      return `timeout (remaining ${context.remainingTime ?? 0}ms)`;
+    case 'signal':
+      return context.signal ? `signal ${context.signal}` : 'process shutdown';
+    default:
+      return context.detail ?? 'manual cleanup';
+  }
+}
+

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,70 +1,77 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { getRedisClient, isRedisReady } from "../cache/redisConnection";
+import { setupLambdaTimeout } from "../shared/lambdaLifecycle";
 
 const dynamo = new DynamoDBClient({});
 
 const withTimeout = <T>(p: Promise<T>, ms = 350) =>
   Promise.race([
-    p, 
+    p,
     new Promise<never>((_, rej) => setTimeout(() => rej(new Error("timeout")), ms))
   ]);
 
-export const handler = async (_evt: any, ctx: any) => {
-  if (ctx && typeof ctx === 'object') {
-    ctx.callbackWaitsForEmptyEventLoop = false;
-  }
+export const handler = async (_evt: any, ctx?: Context): Promise<APIGatewayProxyResult> => {
+  const cancelTimeoutGuard = setupLambdaTimeout(ctx, {
+    bufferMs: 750,
+    logger: (message) => console.warn(`[health] ${message}`)
+  });
 
-  const checks: any = { redis: {}, dynamo: {} };
-  let degraded = false;
-
-  // Redis check - use connection manager
   try {
-    if (isRedisReady()) {
-      // Already connected
-      checks.redis = { ok: true, status: 'ready' };
-    } else {
-      // Try to connect
-      const redis = await withTimeout(getRedisClient(), 500);
-      if (redis) {
-        await withTimeout(redis.ping(), 250);
-        checks.redis = { ok: true, status: 'connected' };
+    const checks: any = { redis: {}, dynamo: {} };
+    let degraded = false;
+
+    // Redis check - use connection manager
+    try {
+      if (isRedisReady()) {
+        // Already connected
+        checks.redis = { ok: true, status: 'ready' };
       } else {
-        throw new Error('Failed to get Redis client');
+        // Try to connect
+        const redis = await withTimeout(getRedisClient(), 500);
+        if (redis) {
+          await withTimeout(redis.ping(), 250);
+          checks.redis = { ok: true, status: 'connected' };
+        } else {
+          throw new Error('Failed to get Redis client');
+        }
       }
+    } catch (e: any) {
+      degraded = true;
+      checks.redis = { ok: false, error: String(e?.message || e) };
     }
-  } catch (e: any) {
-    degraded = true; 
-    checks.redis = { ok: false, error: String(e?.message || e) };
-  }
 
-  // Dynamo check
-  try {
-    await withTimeout(
-      dynamo.send(new GetItemCommand({
-        TableName: process.env.CASES_TABLE!,
-        Key: { pk: { S: "canary" }, sk: { S: "health" } }
-      })), 
-      300
-    );
-    checks.dynamo = { ok: true };
-  } catch (e: any) {
-    degraded = true; 
-    checks.dynamo = { ok: false, error: String(e?.message || e) };
-  }
+    // Dynamo check
+    try {
+      await withTimeout(
+        dynamo.send(new GetItemCommand({
+          TableName: process.env.CASES_TABLE!,
+          Key: { pk: { S: "canary" }, sk: { S: "health" } }
+        })),
+        300
+      );
+      checks.dynamo = { ok: true };
+    } catch (e: any) {
+      degraded = true;
+      checks.dynamo = { ok: false, error: String(e?.message || e) };
+    }
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-cache'
-    },
-    body: JSON.stringify({ 
-      ok: true, 
-      degraded, 
-      checks, 
-      service: 'StripedShield',
-      version: '2.0.1',
-      ts: new Date().toISOString() 
-    })
-  };
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache'
+      },
+      body: JSON.stringify({
+        ok: true,
+        degraded,
+        checks,
+        service: 'StripedShield',
+        version: '2.0.1',
+        ts: new Date().toISOString()
+      })
+    };
+  } finally {
+    cancelTimeoutGuard();
+  }
 };

--- a/src/handlers/metrics.ts
+++ b/src/handlers/metrics.ts
@@ -1,14 +1,19 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { getRedisClient } from '../cache/redisConnection';
 import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { setupLambdaTimeout } from '../shared/lambdaLifecycle';
 
 /**
  * Metrics endpoint for StripedShield
  * Returns performance metrics and win rate statistics
  */
-export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+export const handler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
   const startTime = Date.now();
-  
+  const cancelTimeoutGuard = setupLambdaTimeout(context, {
+    bufferMs: 1000,
+    logger: (message) => console.warn(`[metrics] ${message}`)
+  });
+
   try {
     // Get Redis client from connection manager
     const redis = await getRedisClient();
@@ -91,7 +96,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const customerROI = ((monthlyValueRecovered - monthlyFee) / monthlyFee * 100).toFixed(1);
     
     await redis.quit();
-    
+
     const metrics = {
       timestamp: new Date().toISOString(),
       service: 'StripedShield',
@@ -156,7 +161,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     
   } catch (error: any) {
     console.error('Metrics error:', error);
-    
+
     // Return partial metrics with 200 status
     return {
       statusCode: 200,
@@ -177,5 +182,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         }
       })
     };
+  }
+  finally {
+    cancelTimeoutGuard();
   }
 };

--- a/src/shared/lambdaLifecycle.ts
+++ b/src/shared/lambdaLifecycle.ts
@@ -1,0 +1,121 @@
+import type { Context } from 'aws-lambda';
+
+export interface CleanupContext {
+  type: 'timeout' | 'signal' | 'manual';
+  signal?: NodeJS.Signals;
+  detail?: string;
+  remainingTime?: number;
+}
+
+export type CleanupHandler = (context: CleanupContext) => Promise<void> | void;
+
+const cleanupHandlers = new Set<CleanupHandler>();
+let cleanupInProgress: Promise<void> | null = null;
+let signalHandlersRegistered = false;
+
+export function registerCleanupHandler(handler: CleanupHandler): () => void {
+  cleanupHandlers.add(handler);
+  return () => cleanupHandlers.delete(handler);
+}
+
+export async function runCleanup(context: CleanupContext): Promise<void> {
+  if (cleanupInProgress) {
+    return cleanupInProgress;
+  }
+
+  cleanupInProgress = (async () => {
+    for (const handler of Array.from(cleanupHandlers)) {
+      try {
+        await handler(context);
+      } catch (error) {
+        console.error('[lambdaLifecycle] Cleanup handler failed:', error);
+      }
+    }
+  })();
+
+  try {
+    await cleanupInProgress;
+  } finally {
+    cleanupInProgress = null;
+  }
+}
+
+export function setupLambdaTimeout(
+  context?: Context,
+  options?: { bufferMs?: number; logger?: (message: string) => void }
+): () => void {
+  ensureSignalHandlers();
+
+  if (!context || typeof context.getRemainingTimeInMillis !== 'function') {
+    return () => {};
+  }
+
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const bufferMs = Math.max(options?.bufferMs ?? 1000, 0);
+  const log = options?.logger ?? defaultLogger;
+
+  let cleared = false;
+  let finished = false;
+
+  const schedule = Math.max(0, context.getRemainingTimeInMillis() - bufferMs);
+
+  if (schedule === 0) {
+    log('Lambda timeout buffer exceeded on invocation start, running cleanup immediately');
+    runCleanup({ type: 'timeout', remainingTime: context.getRemainingTimeInMillis?.() }).catch((error) => {
+      console.error('[lambdaLifecycle] Failed to execute timeout cleanup:', error);
+    });
+    finished = true;
+    return () => {};
+  }
+
+  const timer = setTimeout(() => {
+    if (cleared || finished) {
+      return;
+    }
+    finished = true;
+    log('Lambda nearing timeout, running registered cleanup handlers');
+    runCleanup({ type: 'timeout', remainingTime: context.getRemainingTimeInMillis?.() }).catch((error) => {
+      console.error('[lambdaLifecycle] Failed to execute timeout cleanup:', error);
+    });
+  }, schedule);
+
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+
+  return () => {
+    cleared = true;
+    clearTimeout(timer);
+  };
+}
+
+function ensureSignalHandlers(): void {
+  if (signalHandlersRegistered) {
+    return;
+  }
+
+  signalHandlersRegistered = true;
+
+  const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
+
+  for (const signal of signals) {
+    process.once(signal, () => {
+      defaultLogger(`Received ${signal}, running cleanup handlers`);
+      runCleanup({ type: 'signal', signal }).catch((error) => {
+        console.error('[lambdaLifecycle] Cleanup handler failed during signal processing:', error);
+      });
+    });
+  }
+
+  process.once('beforeExit', (code) => {
+    defaultLogger(`Process beforeExit with code ${code}, running cleanup handlers`);
+    runCleanup({ type: 'signal' }).catch((error) => {
+      console.error('[lambdaLifecycle] Cleanup handler failed during beforeExit:', error);
+    });
+  });
+}
+
+function defaultLogger(message: string): void {
+  console.warn(`[lambdaLifecycle] ${message}`);
+}


### PR DESCRIPTION
## Summary
- add a shared Lambda lifecycle helper to coordinate timeout guards, signal handling, and cleanup callbacks
- register the Redis connection manager with the lifecycle cleanup so it can close gracefully when shutdown events occur
- wrap the metrics and health handlers with the timeout guard so they cancel work before the Lambda times out

## Testing
- npm run build *(fails: TS2339 in src/handlers/buildEvidence.ts unrelated to this change)*
- npx tsc --pretty false --module CommonJS --target ES2022 --outDir /tmp/lifecycle-check src/shared/lambdaLifecycle.ts


------
https://chatgpt.com/codex/tasks/task_e_68deea9ec534832f942462a80346df78