### PR TITLE
Add idempotency enforcement for API write operations

### DIFF
--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,105 +1,112 @@
 import { putMerchant } from "../shared/db.js";
 import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { IdempotencyService } from "../shared/idempotency.js";
 
 export async function handler(event:any){
   const qs = event.queryStringParameters || {};
   const code = qs.code;
   const state = qs.state; // Should contain firebase_uid
-  
+
   if(!code) return { statusCode:400, body:'missing code' };
 
-  const body = new URLSearchParams({
-    client_secret: process.env.STRIPE_SECRET!,
-    client_id: process.env.STRIPE_CLIENT_ID!,
-    code, grant_type: 'authorization_code'
-  });
-
-  const r = await fetch('https://connect.stripe.com/oauth/token', {
-    method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
-  });
-  const json:any = await r.json();
-  if(!json.stripe_user_id) return { statusCode:400, body:`oauth failed: ${JSON.stringify(json)}` };
-
-  // Extract all OAuth data
-  const merchant_id = json.stripe_user_id;
-  const access_token = json.access_token;
-  const refresh_token = json.refresh_token;
-  const token_type = json.token_type || 'bearer';
-  const stripe_publishable_key = json.stripe_publishable_key;
-  const scope = json.scope;
-  const livemode = json.livemode || false;
-  
-  // Parse Firebase UID from state if provided
-  let firebase_uid = null;
-  try {
-    if (state) {
-      const stateData = JSON.parse(Buffer.from(state, 'base64').toString());
-      firebase_uid = stateData.firebase_uid;
-    }
-  } catch (e) {
-    console.log('Could not parse state:', e);
-  }
-
-  // Save all OAuth data to DynamoDB
-  await putMerchant({ 
-    merchant_id,
-    stripe_account_id: merchant_id,
-    access_token, // CRITICAL: Save this for API calls
-    refresh_token, // CRITICAL: Save this for token refresh
-    token_type,
-    stripe_publishable_key,
-    scope,
-    livemode,
-    firebase_uid, // Link to Firebase user
-    oauth_connected_at: new Date().toISOString()
-  });
-  
-  // Audit successful OAuth connection
-  await createAuditLog({
-    action: AuditAction.OAUTH_CONNECT,
-    userId: firebase_uid,
-    merchantId: merchant_id,
-    resourceType: 'stripe_account',
-    resourceId: merchant_id,
-    ipAddress: event.requestContext?.identity?.sourceIp,
-    success: true,
-    metadata: {
-      scope,
-      livemode,
-      stripe_publishable_key
-    }
-  });
-
-  // Register webhook endpoint for this connected account
-  try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
-    const webhookEndpoint = await stripe.webhookEndpoints.create({
-      url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
-      enabled_events: [
-        'charge.dispute.created',
-        'charge.dispute.updated', 
-        'charge.dispute.closed',
-        'charge.dispute.funds_reinstated',
-        'charge.dispute.funds_withdrawn'
-      ],
-      connect: true // This makes it a Connect webhook
+  return IdempotencyService.executeWithKey(`stripe_oauth:${code}`, async () => {
+    const body = new URLSearchParams({
+      client_secret: process.env.STRIPE_SECRET!,
+      client_id: process.env.STRIPE_CLIENT_ID!,
+      code, grant_type: 'authorization_code'
     });
-    
-    console.log('Webhook endpoint registered:', webhookEndpoint.id);
-    
-    // Save webhook endpoint ID
+
+    const r = await fetch('https://connect.stripe.com/oauth/token', {
+      method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
+    });
+    const json:any = await r.json();
+    if(!json.stripe_user_id) return { statusCode:400, body:`oauth failed: ${JSON.stringify(json)}` };
+
+    // Extract all OAuth data
+    const merchant_id = json.stripe_user_id;
+    const access_token = json.access_token;
+    const refresh_token = json.refresh_token;
+    const token_type = json.token_type || 'bearer';
+    const stripe_publishable_key = json.stripe_publishable_key;
+    const scope = json.scope;
+    const livemode = json.livemode || false;
+
+    // Parse Firebase UID from state if provided
+    let firebase_uid = null;
+    try {
+      if (state) {
+        const stateData = JSON.parse(Buffer.from(state, 'base64').toString());
+        firebase_uid = stateData.firebase_uid;
+      }
+    } catch (e) {
+      console.log('Could not parse state:', e);
+    }
+
+    // Save all OAuth data to DynamoDB
     await putMerchant({
       merchant_id,
-      webhook_endpoint_id: webhookEndpoint.id,
-      webhook_secret: webhookEndpoint.secret
+      stripe_account_id: merchant_id,
+      access_token, // CRITICAL: Save this for API calls
+      refresh_token, // CRITICAL: Save this for token refresh
+      token_type,
+      stripe_publishable_key,
+      scope,
+      livemode,
+      firebase_uid, // Link to Firebase user
+      oauth_connected_at: new Date().toISOString()
     });
-  } catch (webhookError) {
-    console.error('Failed to register webhook:', webhookError);
-    // Continue even if webhook registration fails
-  }
 
-  // Redirect to frontend connect page with success
-  const frontendCallbackUrl = `https://stripedshield-founders-1755231149.netlify.app/connect.html?success=true&stripe_account_id=${merchant_id}${firebase_uid ? '&uid=' + firebase_uid : ''}`;
-  return { statusCode: 302, headers: { Location: frontendCallbackUrl }, body: '' };
+    // Audit successful OAuth connection
+    await createAuditLog({
+      action: AuditAction.OAUTH_CONNECT,
+      userId: firebase_uid,
+      merchantId: merchant_id,
+      resourceType: 'stripe_account',
+      resourceId: merchant_id,
+      ipAddress: event.requestContext?.identity?.sourceIp,
+      success: true,
+      metadata: {
+        scope,
+        livemode,
+        stripe_publishable_key
+      }
+    });
+
+    // Register webhook endpoint for this connected account
+    try {
+      const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+      const webhookEndpoint = await stripe.webhookEndpoints.create({
+        url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
+        enabled_events: [
+          'charge.dispute.created',
+          'charge.dispute.updated',
+          'charge.dispute.closed',
+          'charge.dispute.funds_reinstated',
+          'charge.dispute.funds_withdrawn'
+        ],
+        connect: true // This makes it a Connect webhook
+      });
+
+      console.log('Webhook endpoint registered:', webhookEndpoint.id);
+
+      // Save webhook endpoint ID
+      await putMerchant({
+        merchant_id,
+        webhook_endpoint_id: webhookEndpoint.id,
+        webhook_secret: webhookEndpoint.secret
+      });
+    } catch (webhookError) {
+      console.error('Failed to register webhook:', webhookError);
+      // Continue even if webhook registration fails
+    }
+
+    // Redirect to frontend connect page with success
+    const frontendCallbackUrl = `https://stripedshield-founders-1755231149.netlify.app/connect.html?success=true&stripe_account_id=${merchant_id}${firebase_uid ? '&uid=' + firebase_uid : ''}`;
+    return { statusCode: 302, headers: { Location: frontendCallbackUrl }, body: '' };
+  }, {
+    event: 'stripe_oauth_callback',
+    state,
+    sourceIp: event.requestContext?.identity?.sourceIp
+  });
 }

--- a/src/handlers/collectCase.ts
+++ b/src/handlers/collectCase.ts
@@ -1,37 +1,39 @@
 import { bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
-import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { StartExecutionCommand, SFNClient as StepFunctionsClient } from "@aws-sdk/client-sfn";
+import { IdempotencyService } from "../shared/idempotency.js";
 
 const sfn = new StepFunctionsClient({});
 
 export async function handler(event:any){
-  // REQUIRE AUTHENTICATION
-  const authResult = await requireAuth(event);
-  if ('statusCode' in authResult) {
-    return authResult; // Return 401 if not authenticated
-  }
-  const authContext = authResult;
-  
-  const id = event.pathParameters?.id;
-  const qs = event.queryStringParameters || {};
-  const merchantId = qs.merchant || authContext.merchant_id;
-  
-  if(!merchantId || !id) return bad("missing merchant or id");
-  
-  // VERIFY USER OWNS THIS MERCHANT ACCOUNT
-  const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
-  if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
-  }
+  return IdempotencyService.handleHttp(event, async () => {
+    // REQUIRE AUTHENTICATION
+    const authResult = await requireAuth(event);
+    if ('statusCode' in authResult) {
+      return authResult; // Return 401 if not authenticated
+    }
+    const authContext = authResult;
 
-  await sfn.send(new StartExecutionCommand({
-    stateMachineArn: process.env.SFN_ARN!,
-    input: JSON.stringify({ merchant: { stripe_account_id: merchantId }, dispute_id: id })
-  }));
+    const id = event.pathParameters?.id;
+    const qs = event.queryStringParameters || {};
+    const merchantId = qs.merchant || authContext.merchant_id;
 
-  return { statusCode:202, body:'started' };
+    if(!merchantId || !id) return bad("missing merchant or id");
+
+    // VERIFY USER OWNS THIS MERCHANT ACCOUNT
+    const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
+    if (!hasAccess) {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ error: 'Access denied to this merchant account' })
+      };
+    }
+
+    await sfn.send(new StartExecutionCommand({
+      stateMachineArn: process.env.SFN_ARN!,
+      input: JSON.stringify({ merchant: { stripe_account_id: merchantId }, dispute_id: id })
+    }));
+
+    return { statusCode:202, body:'started' };
+  });
 }

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -1,81 +1,84 @@
 import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
+import { IdempotencyService } from "../shared/idempotency.js";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
-  // Get auth context if user is logged in (optional for checkout)
-  let authContext = null;
-  try {
-    const authResult = await requireAuth(event);
-    if (!('statusCode' in authResult)) {
-      authContext = authResult;
+  return IdempotencyService.handleHttp(event, async () => {
+    // Get auth context if user is logged in (optional for checkout)
+    let authContext = null;
+    try {
+      const authResult = await requireAuth(event);
+      if (!('statusCode' in authResult)) {
+        authContext = authResult;
+      }
+    } catch (e) {
+      // User not logged in, that's okay for checkout
     }
-  } catch (e) {
-    // User not logged in, that's okay for checkout
-  }
-  
-  const body = JSON.parse(event.body || '{}');
-  const email = body.email || authContext?.email;
-  const priceId = body.price_id || process.env.STRIPE_PRICE_ID || 'price_1QWtQxDOwkStzJVXK8PqXJ0z'; // Default founder price
-  
-  if (!email) {
-    return bad('Email is required');
-  }
-  
-  try {
-    // Create or retrieve customer
-    const customers = await stripe.customers.list({
-      email: email,
-      limit: 1
-    });
-    
-    let customer;
-    if (customers.data.length > 0) {
-      customer = customers.data[0];
-    } else {
-      customer = await stripe.customers.create({
+
+    const body = JSON.parse(event.body || '{}');
+    const email = body.email || authContext?.email;
+    const priceId = body.price_id || process.env.STRIPE_PRICE_ID || 'price_1QWtQxDOwkStzJVXK8PqXJ0z'; // Default founder price
+
+    if (!email) {
+      return bad('Email is required');
+    }
+
+    try {
+      // Create or retrieve customer
+      const customers = await stripe.customers.list({
         email: email,
+        limit: 1
+      });
+
+      let customer;
+      if (customers.data.length > 0) {
+        customer = customers.data[0];
+      } else {
+        customer = await stripe.customers.create({
+          email: email,
+          metadata: {
+            firebase_uid: authContext?.uid || '',
+            source: 'stripedshield_checkout'
+          }
+        });
+      }
+
+      // Create checkout session
+      const session = await stripe.checkout.sessions.create({
+        customer: customer.id,
+        payment_method_types: ['card'],
+        mode: 'subscription',
+        line_items: [{
+          price: priceId,
+          quantity: 1
+        }],
+        subscription_data: {
+          trial_period_days: 7,
+          metadata: {
+            firebase_uid: authContext?.uid || '',
+            merchant_id: authContext?.merchant_id || ''
+          }
+        },
+        success_url: 'https://stripedshield-founders-1755231149.netlify.app/dashboard-protected.html?payment=success',
+        cancel_url: 'https://stripedshield-founders-1755231149.netlify.app/checkout.html?payment=cancelled',
+        client_reference_id: authContext?.uid || email, // Link to Firebase user
         metadata: {
           firebase_uid: authContext?.uid || '',
-          source: 'stripedshield_checkout'
+          email: email
         }
       });
+
+      return ok({
+        checkout_url: session.url,
+        session_id: session.id
+      });
+
+    } catch (error: any) {
+      console.error('Checkout session error:', error);
+      return bad(error.message);
     }
-    
-    // Create checkout session
-    const session = await stripe.checkout.sessions.create({
-      customer: customer.id,
-      payment_method_types: ['card'],
-      mode: 'subscription',
-      line_items: [{
-        price: priceId,
-        quantity: 1
-      }],
-      subscription_data: {
-        trial_period_days: 7,
-        metadata: {
-          firebase_uid: authContext?.uid || '',
-          merchant_id: authContext?.merchant_id || ''
-        }
-      },
-      success_url: 'https://stripedshield-founders-1755231149.netlify.app/dashboard-protected.html?payment=success',
-      cancel_url: 'https://stripedshield-founders-1755231149.netlify.app/checkout.html?payment=cancelled',
-      client_reference_id: authContext?.uid || email, // Link to Firebase user
-      metadata: {
-        firebase_uid: authContext?.uid || '',
-        email: email
-      }
-    });
-    
-    return ok({ 
-      checkout_url: session.url,
-      session_id: session.id
-    });
-    
-  } catch (error: any) {
-    console.error('Checkout session error:', error);
-    return bad(error.message);
-  }
+  });
 }

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -2,65 +2,68 @@ import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { IdempotencyService } from "../shared/idempotency.js";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
  */
 export async function handler(event: any) {
-  // REQUIRE AUTHENTICATION
-  const authResult = await requireAuth(event);
-  if ('statusCode' in authResult) {
-    return authResult;
-  }
-  const authContext = authResult;
-  
-  if (!authContext.merchant_id) {
-    return bad('No Stripe account connected');
-  }
-  
-  try {
-    // Get merchant record with refresh token
-    const merchant = await getMerchantByAccount(authContext.stripe_account_id!);
-    
-    if (!merchant.refresh_token) {
-      return bad('No refresh token available. Please reconnect your Stripe account.');
+  return IdempotencyService.handleHttp(event, async () => {
+    // REQUIRE AUTHENTICATION
+    const authResult = await requireAuth(event);
+    if ('statusCode' in authResult) {
+      return authResult;
     }
-    
-    // Refresh the token
-    const body = new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: merchant.refresh_token,
-      client_secret: process.env.STRIPE_SECRET!
-    });
-    
-    const response = await fetch('https://connect.stripe.com/oauth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body
-    });
-    
-    const json: any = await response.json();
-    
-    if (!json.access_token) {
-      console.error('Token refresh failed:', json);
-      return bad('Failed to refresh token: ' + (json.error_description || json.error));
+    const authContext = authResult;
+
+    if (!authContext.merchant_id) {
+      return bad('No Stripe account connected');
     }
-    
-    // Save new tokens
-    await putMerchant({
-      merchant_id: authContext.merchant_id,
-      access_token: json.access_token,
-      refresh_token: json.refresh_token || merchant.refresh_token, // Use new refresh token if provided
-      token_refreshed_at: new Date().toISOString()
-    });
-    
-    return ok({
-      message: 'Token refreshed successfully',
-      expires_in: json.expires_in || 3600
-    });
-    
-  } catch (error: any) {
-    console.error('Token refresh error:', error);
-    return bad('Failed to refresh token: ' + error.message);
-  }
+
+    try {
+      // Get merchant record with refresh token
+      const merchant = await getMerchantByAccount(authContext.stripe_account_id!);
+
+      if (!merchant.refresh_token) {
+        return bad('No refresh token available. Please reconnect your Stripe account.');
+      }
+
+      // Refresh the token
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: merchant.refresh_token,
+        client_secret: process.env.STRIPE_SECRET!
+      });
+
+      const response = await fetch('https://connect.stripe.com/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body
+      });
+
+      const json: any = await response.json();
+
+      if (!json.access_token) {
+        console.error('Token refresh failed:', json);
+        return bad('Failed to refresh token: ' + (json.error_description || json.error));
+      }
+
+      // Save new tokens
+      await putMerchant({
+        merchant_id: authContext.merchant_id,
+        access_token: json.access_token,
+        refresh_token: json.refresh_token || merchant.refresh_token, // Use new refresh token if provided
+        token_refreshed_at: new Date().toISOString()
+      });
+
+      return ok({
+        message: 'Token refreshed successfully',
+        expires_in: json.expires_in || 3600
+      });
+
+    } catch (error: any) {
+      console.error('Token refresh error:', error);
+      return bad('Failed to refresh token: ' + error.message);
+    }
+  });
 }

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -3,206 +3,208 @@ import { getCase } from "../shared/db.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
 import Stripe from 'stripe';
+import { IdempotencyService } from "../shared/idempotency.js";
 
 const sfn = new SFNClient({});
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
 
 export async function handler(event: any) {
-  // REQUIRE AUTHENTICATION
-  const authResult = await requireAuth(event);
-  if ('statusCode' in authResult) {
-    return authResult; // Return 401 if not authenticated
-  }
-  const authContext = authResult;
-  
-  const disputeId = event.pathParameters?.id;
-  if (!disputeId) {
-    return bad("Missing dispute ID");
-  }
-  
-  // Get merchant ID from auth context or query params
-  const merchantId = authContext.merchant_id || event.queryStringParameters?.merchant;
-  if (!merchantId) {
-    return bad("No merchant account connected");
-  }
-  
-  // VERIFY USER OWNS THIS MERCHANT ACCOUNT
-  const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
-  if (!hasAccess) {
-    return createErrorResponse(403, 'Access denied', {
-      error: 'You do not have access to this merchant account'
-    });
-  }
-  
-  try {
-    // Get the case from database
-    const caseData = await getCase(merchantId, disputeId);
-    if (!caseData) {
-      return createErrorResponse(404, 'Not found', {
-        error: 'Dispute not found'
+  return IdempotencyService.handleHttp(event, async () => {
+    // REQUIRE AUTHENTICATION
+    const authResult = await requireAuth(event);
+    if ('statusCode' in authResult) {
+      return authResult; // Return 401 if not authenticated
+    }
+    const authContext = authResult;
+
+    const disputeId = event.pathParameters?.id;
+    if (!disputeId) {
+      return bad("Missing dispute ID");
+    }
+
+    // Get merchant ID from auth context or query params
+    const merchantId = authContext.merchant_id || event.queryStringParameters?.merchant;
+    if (!merchantId) {
+      return bad("No merchant account connected");
+    }
+
+    // VERIFY USER OWNS THIS MERCHANT ACCOUNT
+    const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
+    if (!hasAccess) {
+      return createErrorResponse(403, 'Access denied', {
+        error: 'You do not have access to this merchant account'
       });
     }
-    
-    // Check if dispute is in a retryable state
-    const retryableStatuses = ['needs_response', 'warning_needs_response', 'warning_under_review'];
-    if (!retryableStatuses.includes(caseData.status)) {
-      return createErrorResponse(400, 'Invalid state', {
-        error: `Cannot retry dispute in status: ${caseData.status}`,
-        allowedStatuses: retryableStatuses
-      });
-    }
-    
-    // Get fresh dispute data from Stripe
-    let stripeOptions: any = {};
-    if (merchantId !== 'direct') {
-      stripeOptions = { stripeAccount: merchantId };
-    }
-    
-    const dispute = await stripe.disputes.retrieve(disputeId, stripeOptions);
-    
-    // Check if evidence deadline has passed
-    if (dispute.evidence_details?.due_by) {
-      const deadline = new Date(dispute.evidence_details.due_by * 1000);
-      if (deadline < new Date()) {
-        return createErrorResponse(400, 'Deadline passed', {
-          error: 'Evidence submission deadline has passed',
-          deadline: deadline.toISOString()
+
+    try {
+      // Get the case from database
+      const caseData = await getCase(merchantId, disputeId);
+      if (!caseData) {
+        return createErrorResponse(404, 'Not found', {
+          error: 'Dispute not found'
         });
       }
-    }
-    
-    // Prepare input for Step Functions
-    const sfnInput = {
-      merchant: { 
-        stripe_account_id: merchantId,
-        access_token: caseData.merchant_access_token // Include OAuth token if available
-      },
-      dispute_id: disputeId,
-      retry: true,
-      retry_reason: event.body ? JSON.parse(event.body).reason : 'Manual retry requested',
-      retry_timestamp: new Date().toISOString()
-    };
-    
-    // Start Step Functions execution for retry
-    if (process.env.SFN_ARN) {
-      const executionName = `retry-${disputeId}-${Date.now()}`;
-      await sfn.send(new StartExecutionCommand({
-        stateMachineArn: process.env.SFN_ARN,
-        name: executionName,
-        input: JSON.stringify(sfnInput)
-      }));
-      
-      console.log(`Started retry for dispute ${disputeId} with execution: ${executionName}`);
-      
-      return ok({
-        message: 'Retry initiated successfully',
+
+      // Check if dispute is in a retryable state
+      const retryableStatuses = ['needs_response', 'warning_needs_response', 'warning_under_review'];
+      if (!retryableStatuses.includes(caseData.status)) {
+        return createErrorResponse(400, 'Invalid state', {
+          error: `Cannot retry dispute in status: ${caseData.status}`,
+          allowedStatuses: retryableStatuses
+        });
+      }
+
+      // Get fresh dispute data from Stripe
+      let stripeOptions: any = {};
+      if (merchantId !== 'direct') {
+        stripeOptions = { stripeAccount: merchantId };
+      }
+
+      const dispute = await stripe.disputes.retrieve(disputeId, stripeOptions);
+
+      // Check if evidence deadline has passed
+      if (dispute.evidence_details?.due_by) {
+        const deadline = new Date(dispute.evidence_details.due_by * 1000);
+        if (deadline < new Date()) {
+          return createErrorResponse(400, 'Deadline passed', {
+            error: 'Evidence submission deadline has passed',
+            deadline: deadline.toISOString()
+          });
+        }
+      }
+
+      // Prepare input for Step Functions
+      const sfnInput = {
+        merchant: {
+          stripe_account_id: merchantId,
+          access_token: caseData.merchant_access_token // Include OAuth token if available
+        },
         dispute_id: disputeId,
-        execution_name: executionName,
-        status: caseData.status,
-        deadline: dispute.evidence_details?.due_by ? 
-          new Date(dispute.evidence_details.due_by * 1000).toISOString() : null
-      });
-    } else {
-      // Fallback: Direct evidence collection and submission
-      console.log('No Step Functions configured, attempting direct retry');
-      
-      try {
-        // Import the necessary handlers dynamically
-        const { handler: getDisputeHandler } = await import('./getDispute.js');
-        const { handler: getChargeHandler } = await import('./getCharge.js');
-        const { handler: getPaymentIntentHandler } = await import('./getPaymentIntent.js');
-        const { handler: buildEvidenceHandler } = await import('./buildEvidence.js');
-        const { handler: stageEvidenceHandler } = await import('./stripeStageEvidence.js');
-        const { handler: submitEvidenceHandler } = await import('./stripeSubmitEvidence.js');
-        
-        console.log('Starting direct retry workflow for dispute:', disputeId);
-        
-        // Step 1: Get fresh dispute data
-        const disputeEvent = {
-          pathParameters: { id: disputeId },
-          queryStringParameters: { merchant: merchantId }
-        };
-        const disputeResponse = await getDisputeHandler(disputeEvent);
-        const freshDispute = JSON.parse(disputeResponse.body);
-        
-        // Step 2: Get charge data
-        let charge = null;
-        if (freshDispute.charge) {
-          const chargeEvent = {
-            pathParameters: { id: freshDispute.charge },
+        retry: true,
+        retry_reason: event.body ? JSON.parse(event.body).reason : 'Manual retry requested',
+        retry_timestamp: new Date().toISOString()
+      };
+
+      // Start Step Functions execution for retry
+      if (process.env.SFN_ARN) {
+        const executionName = `retry-${disputeId}-${Date.now()}`;
+        await sfn.send(new StartExecutionCommand({
+          stateMachineArn: process.env.SFN_ARN,
+          name: executionName,
+          input: JSON.stringify(sfnInput)
+        }));
+
+        console.log(`Started retry for dispute ${disputeId} with execution: ${executionName}`);
+
+        return ok({
+          message: 'Retry initiated successfully',
+          dispute_id: disputeId,
+          execution_name: executionName,
+          status: caseData.status,
+          deadline: dispute.evidence_details?.due_by ?
+            new Date(dispute.evidence_details.due_by * 1000).toISOString() : null
+        });
+      } else {
+        // Fallback: Direct evidence collection and submission
+        console.log('No Step Functions configured, attempting direct retry');
+
+        try {
+          // Import the necessary handlers dynamically
+          const { handler: getDisputeHandler } = await import('./getDispute.js');
+          const { handler: getChargeHandler } = await import('./getCharge.js');
+          const { handler: getPaymentIntentHandler } = await import('./getPaymentIntent.js');
+          const { handler: buildEvidenceHandler } = await import('./buildEvidence.js');
+          const { handler: stageEvidenceHandler } = await import('./stripeStageEvidence.js');
+          const { handler: submitEvidenceHandler } = await import('./stripeSubmitEvidence.js');
+
+          console.log('Starting direct retry workflow for dispute:', disputeId);
+
+          // Step 1: Get fresh dispute data
+          const disputeEvent = {
+            pathParameters: { id: disputeId },
             queryStringParameters: { merchant: merchantId }
           };
-          const chargeResponse = await getChargeHandler(chargeEvent);
-          charge = JSON.parse(chargeResponse.body);
-        }
-        
-        // Step 3: Get payment intent data (optional)
-        let paymentIntent = null;
-        if (freshDispute.payment_intent) {
-          try {
-            const paymentIntentEvent = {
-              pathParameters: { id: freshDispute.payment_intent },
+          const disputeResponse = await getDisputeHandler(disputeEvent);
+          const freshDispute = JSON.parse(disputeResponse.body);
+
+          // Step 2: Get charge data
+          let charge = null;
+          if (freshDispute.charge) {
+            const chargeEvent = {
+              pathParameters: { id: freshDispute.charge },
               queryStringParameters: { merchant: merchantId }
             };
-            const paymentIntentResponse = await getPaymentIntentHandler(paymentIntentEvent);
-            paymentIntent = JSON.parse(paymentIntentResponse.body);
-          } catch (piError) {
-            console.log('Payment intent not found, continuing without it');
+            const chargeResponse = await getChargeHandler(chargeEvent);
+            charge = JSON.parse(chargeResponse.body);
           }
-        }
-        
-        // Step 4: Build evidence
-        const buildEvidenceEvent = {
-          dispute: freshDispute,
-          charge,
-          payment_intent: paymentIntent,
-          merchant: {
-            stripe_account_id: merchantId,
-            access_token: caseData.merchant_access_token,
-            settings: { autoSubmit: true } // Force submit on retry
+
+          // Step 3: Get payment intent data (optional)
+          let paymentIntent = null;
+          if (freshDispute.payment_intent) {
+            try {
+              const paymentIntentEvent = {
+                pathParameters: { id: freshDispute.payment_intent },
+                queryStringParameters: { merchant: merchantId }
+              };
+              const paymentIntentResponse = await getPaymentIntentHandler(paymentIntentEvent);
+              paymentIntent = JSON.parse(paymentIntentResponse.body);
+            } catch (piError) {
+              console.log('Payment intent not found, continuing without it');
+            }
           }
-        };
-        const evidenceResult = await buildEvidenceHandler(buildEvidenceEvent);
-        
-        // Step 5: Stage evidence
-        const stageEvent = {
-          dispute: freshDispute,
-          evidence: evidenceResult.evidence,
-          merchant: {
-            stripe_account_id: merchantId,
-            access_token: caseData.merchant_access_token
-          }
-        };
-        const stageResult = await stageEvidenceHandler(stageEvent);
-        
-        // Step 6: Submit evidence if staging succeeded
-        if (stageResult.staged) {
-          const submitEvent = {
+
+          // Step 4: Build evidence
+          const buildEvidenceEvent = {
             dispute: freshDispute,
+            charge,
+            payment_intent: paymentIntent,
+            merchant: {
+              stripe_account_id: merchantId,
+              access_token: caseData.merchant_access_token,
+              settings: { autoSubmit: true } // Force submit on retry
+            }
+          };
+          const evidenceResult = await buildEvidenceHandler(buildEvidenceEvent);
+
+          // Step 5: Stage evidence
+          const stageEvent = {
+            dispute: freshDispute,
+            evidence: evidenceResult.evidence,
             merchant: {
               stripe_account_id: merchantId,
               access_token: caseData.merchant_access_token
             }
           };
-          const submitResult = await submitEvidenceHandler(submitEvent);
-          
-          console.log('Direct retry completed successfully:', submitResult);
-          
-          return ok({
-            message: 'Evidence submitted successfully via direct retry',
-            dispute_id: disputeId,
-            evidence_submitted: true,
-            submission_result: submitResult,
-            workflow: 'direct'
-          });
-        } else {
-          return ok({
-            message: 'Evidence staged but not submitted (manual review required)',
-            dispute_id: disputeId,
-            evidence_staged: true,
-            workflow: 'direct'
-          });
-        }
+          const stageResult = await stageEvidenceHandler(stageEvent);
+
+          // Step 6: Submit evidence if staging succeeded
+          if (stageResult.staged) {
+            const submitEvent = {
+              dispute: freshDispute,
+              merchant: {
+                stripe_account_id: merchantId,
+                access_token: caseData.merchant_access_token
+              }
+            };
+            const submitResult = await submitEvidenceHandler(submitEvent);
+
+            console.log('Direct retry completed successfully:', submitResult);
+
+            return ok({
+              message: 'Evidence submitted successfully via direct retry',
+              dispute_id: disputeId,
+              evidence_submitted: true,
+              submission_result: submitResult,
+              workflow: 'direct'
+            });
+          } else {
+            return ok({
+              message: 'Evidence staged but not submitted (manual review required)',
+              dispute_id: disputeId,
+              evidence_staged: true,
+              workflow: 'direct'
+            });
+          }
         
       } catch (directRetryError: any) {
         console.error('Direct retry failed:', directRetryError);
@@ -216,11 +218,12 @@ export async function handler(event: any) {
       }
     }
     
-  } catch (error: any) {
-    console.error('Error retrying dispute:', error);
-    return createErrorResponse(500, 'Internal error', {
-      error: 'Failed to retry dispute',
-      details: error.message
-    });
-  }
+    } catch (error: any) {
+      console.error('Error retrying dispute:', error);
+      return createErrorResponse(500, 'Internal error', {
+        error: 'Failed to retry dispute',
+        details: error.message
+      });
+    }
+  });
 }

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -1,6 +1,7 @@
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
+import { IdempotencyService } from "../shared/idempotency.js";
 import Stripe from 'stripe';
 import { 
   predictWinRate, 
@@ -42,31 +43,32 @@ async function publishMetric(name: string, value: number, unit: string = 'Count'
 }
 
 export async function handler(event:any){
-  // REQUIRE AUTHENTICATION
-  const authResult = await requireAuth(event);
-  if ('statusCode' in authResult) {
-    return authResult; // Return 401 if not authenticated
-  }
-  const authContext = authResult;
-  
-  const id = event.pathParameters?.id;
-  const qs = event.queryStringParameters || {};
-  const merchantId = qs.merchant || authContext.merchant_id;
-  const forceSubmit = qs.force === 'true'; // Allow forcing immediate submission
-  
-  if(!merchantId || !id) return bad("missing merchant or id");
-  
-  // VERIFY USER OWNS THIS MERCHANT ACCOUNT
-  const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
-  if (!hasAccess) {
-    await createAuditLog({
-      action: AuditAction.UNAUTHORIZED_ACCESS,
-      userId: authContext.uid,
-      userEmail: authContext.email,
-      resourceType: 'dispute',
-      resourceId: id,
-      success: false,
-      errorMessage: 'Attempted to submit evidence for unauthorized merchant'
+  return IdempotencyService.handleHttp(event, async () => {
+      // REQUIRE AUTHENTICATION
+      const authResult = await requireAuth(event);
+      if ('statusCode' in authResult) {
+        return authResult; // Return 401 if not authenticated
+      }
+      const authContext = authResult;
+      
+      const id = event.pathParameters?.id;
+      const qs = event.queryStringParameters || {};
+      const merchantId = qs.merchant || authContext.merchant_id;
+      const forceSubmit = qs.force === 'true'; // Allow forcing immediate submission
+      
+      if(!merchantId || !id) return bad("missing merchant or id");
+      
+      // VERIFY USER OWNS THIS MERCHANT ACCOUNT
+      const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
+      if (!hasAccess) {
+        await createAuditLog({
+          action: AuditAction.UNAUTHORIZED_ACCESS,
+          userId: authContext.uid,
+          userEmail: authContext.email,
+          resourceType: 'dispute',
+          resourceId: id,
+          success: false,
+          errorMessage: 'Attempted to submit evidence for unauthorized merchant'
     });
     return {
       statusCode: 403,
@@ -268,4 +270,5 @@ export async function handler(event:any){
     console.error('Error submitting dispute:', error);
     return bad(`Failed to submit dispute: ${error.message}`);
   }
+  });
 }

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -2,6 +2,7 @@ import { ok, bad } from "../shared/responses.js";
 import { requireAuth, verifyMerchantOwnership } from "../shared/auth.js";
 import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
+import { IdempotencyService } from "../shared/idempotency.js";
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
@@ -290,76 +291,78 @@ export async function getSubscriptionStatus(event: any) {
 
 // API endpoint to cancel subscription
 export async function cancelSubscription(event: any) {
-  // Require authentication
-  const authResult = await requireAuth(event);
-  if ('statusCode' in authResult) {
-    return authResult;
-  }
-  const authContext = authResult;
-  
-  const merchantId = event.queryStringParameters?.merchant || authContext.merchant_id;
-  
-  if (!merchantId) {
-    return bad("No merchant account specified");
-  }
-  
-  // Verify ownership
-  const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
-  if (!hasAccess) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Access denied to this merchant account' })
-    };
-  }
-  
-  try {
-    // Get merchant data
-    const merchant = await getCase(merchantId, 'MERCHANT');
-    
-    if (!merchant?.subscription_id) {
-      return bad("No active subscription found");
+  return IdempotencyService.handleHttp(event, async () => {
+    // Require authentication
+    const authResult = await requireAuth(event);
+    if ('statusCode' in authResult) {
+      return authResult;
     }
-    
-    // Cancel subscription at period end
-    const canceledSubscription = await stripe.subscriptions.update(
-      merchant.subscription_id,
-      { cancel_at_period_end: true }
-    );
-    
-    // Update merchant record
-    await putMerchant({
-      merchant_id: merchantId,
-      subscription_cancel_at_period_end: true,
-      subscription_cancel_requested_at: new Date().toISOString()
-    });
-    
-    // Audit the cancellation
-    await createAuditLog({
-      action: AuditAction.SUBSCRIPTION_CANCELLED,
-      userId: authContext.uid,
-      userEmail: authContext.email,
-      merchantId: merchantId,
-      resourceType: 'subscription',
-      resourceId: merchant.subscription_id,
-      success: true,
-      metadata: {
-        cancel_at: canceledSubscription.cancel_at,
-        current_period_end: (canceledSubscription as any).current_period_end
+    const authContext = authResult;
+
+    const merchantId = event.queryStringParameters?.merchant || authContext.merchant_id;
+
+    if (!merchantId) {
+      return bad("No merchant account specified");
+    }
+
+    // Verify ownership
+    const hasAccess = await verifyMerchantOwnership(authContext, merchantId);
+    if (!hasAccess) {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ error: 'Access denied to this merchant account' })
+      };
+    }
+
+    try {
+      // Get merchant data
+      const merchant = await getCase(merchantId, 'MERCHANT');
+
+      if (!merchant?.subscription_id) {
+        return bad("No active subscription found");
       }
-    });
-    
-    return ok({
-      message: 'Subscription will be canceled at the end of the current billing period',
-      subscription: {
-        id: canceledSubscription.id,
-        status: canceledSubscription.status,
-        cancel_at_period_end: canceledSubscription.cancel_at_period_end,
-        current_period_end: (canceledSubscription as any).current_period_end
-      }
-    });
-    
-  } catch (error: any) {
-    console.error('Error canceling subscription:', error);
-    return bad(`Failed to cancel subscription: ${error.message}`);
-  }
+
+      // Cancel subscription at period end
+      const canceledSubscription = await stripe.subscriptions.update(
+        merchant.subscription_id,
+        { cancel_at_period_end: true }
+      );
+
+      // Update merchant record
+      await putMerchant({
+        merchant_id: merchantId,
+        subscription_cancel_at_period_end: true,
+        subscription_cancel_requested_at: new Date().toISOString()
+      });
+
+      // Audit the cancellation
+      await createAuditLog({
+        action: AuditAction.SUBSCRIPTION_CANCELLED,
+        userId: authContext.uid,
+        userEmail: authContext.email,
+        merchantId: merchantId,
+        resourceType: 'subscription',
+        resourceId: merchant.subscription_id,
+        success: true,
+        metadata: {
+          cancel_at: canceledSubscription.cancel_at,
+          current_period_end: (canceledSubscription as any).current_period_end
+        }
+      });
+
+      return ok({
+        message: 'Subscription will be canceled at the end of the current billing period',
+        subscription: {
+          id: canceledSubscription.id,
+          status: canceledSubscription.status,
+          cancel_at_period_end: canceledSubscription.cancel_at_period_end,
+          current_period_end: (canceledSubscription as any).current_period_end
+        }
+      });
+
+    } catch (error: any) {
+      console.error('Error canceling subscription:', error);
+      return bad(`Failed to cancel subscription: ${error.message}`);
+    }
+  });
 }

--- a/src/shared/idempotency.ts
+++ b/src/shared/idempotency.ts
@@ -1,0 +1,300 @@
+import crypto from 'crypto';
+import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb } from './ddb.js';
+
+const IDEMPOTENCY_TABLE = process.env.IDEMPOTENCY_TABLE || process.env.CASES_TABLE || 'CasesTable';
+const IDEMPOTENCY_TTL_HOURS = Number(process.env.IDEMPOTENCY_TTL_HOURS || '24');
+const IDEMPOTENCY_SORT_KEY = 'IDEMPOTENCY';
+
+export interface StoredHttpResponse {
+  statusCode: number;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+interface IdempotencyRecord {
+  pk: string;
+  sk: string;
+  key: string;
+  status: 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+  response?: StoredHttpResponse;
+  error?: string;
+  metadata?: Record<string, any>;
+  createdAt: string;
+  updatedAt: string;
+  ttl: number;
+}
+
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function defaultHeaders(): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Authorization,Content-Type,X-Requested-With,X-Request-ID,Idempotency-Key',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'Access-Control-Allow-Credentials': 'true'
+  };
+}
+
+function mergeHeaderValues(existing: string, incoming: string): string {
+  const existingParts = existing.split(',').map((part) => part.trim()).filter(Boolean);
+  const incomingParts = incoming.split(',').map((part) => part.trim()).filter(Boolean);
+  const merged = new Set<string>(existingParts);
+  for (const part of incomingParts) {
+    if (part) {
+      merged.add(part);
+    }
+  }
+  return Array.from(merged).join(',');
+}
+
+function normalizeHeaders(headers?: Record<string, any>): Record<string, string> {
+  const base = defaultHeaders();
+  if (!headers) return base;
+  const normalized: Record<string, string> = { ...base };
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    const stringValue = String(value);
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'access-control-allow-headers') {
+      normalized[key] = mergeHeaderValues(base['Access-Control-Allow-Headers'], stringValue + ',Idempotency-Key');
+    } else if (lowerKey === 'access-control-allow-methods') {
+      normalized[key] = mergeHeaderValues(base['Access-Control-Allow-Methods'], stringValue);
+    } else {
+      normalized[key] = stringValue;
+    }
+  }
+  return normalized;
+}
+
+function normalizeResponse(result: any): StoredHttpResponse {
+  if (!result || typeof result !== 'object') {
+    return {
+      statusCode: 200,
+      headers: defaultHeaders(),
+      body: JSON.stringify(result ?? {})
+    };
+  }
+
+  const statusCode = typeof result.statusCode === 'number' ? result.statusCode : 200;
+  const headers = normalizeHeaders(result.headers as Record<string, any> | undefined);
+  let body: string | undefined;
+
+  if (typeof result.body === 'string') {
+    body = result.body;
+  } else if (result.body !== undefined) {
+    body = JSON.stringify(result.body);
+  } else if ('statusCode' in result) {
+    body = '';
+  } else {
+    body = JSON.stringify(result);
+  }
+
+  return { statusCode, headers, body };
+}
+
+function deserializeResponse(record: StoredHttpResponse): StoredHttpResponse {
+  const headers = normalizeHeaders(record.headers);
+  return {
+    statusCode: record.statusCode,
+    headers,
+    body: record.body ?? ''
+  };
+}
+
+function ttlSeconds(): number {
+  return Math.floor(Date.now() / 1000) + IDEMPOTENCY_TTL_HOURS * 3600;
+}
+
+function buildPartitionKey(key: string): string {
+  return `IDEMPOTENCY#${key}`;
+}
+
+async function getRecord(partitionKey: string): Promise<IdempotencyRecord | null> {
+  const result = await ddb.send(new GetCommand({
+    TableName: IDEMPOTENCY_TABLE,
+    Key: { pk: partitionKey, sk: IDEMPOTENCY_SORT_KEY }
+  }));
+
+  return (result.Item as IdempotencyRecord | undefined) || null;
+}
+
+async function putRecord(record: IdempotencyRecord, condition?: string) {
+  await ddb.send(new PutCommand({
+    TableName: IDEMPOTENCY_TABLE,
+    Item: record,
+    ...(condition ? { ConditionExpression: condition } : {})
+  }));
+}
+
+function missingKeyResponse(): StoredHttpResponse {
+  return {
+    statusCode: 400,
+    headers: defaultHeaders(),
+    body: JSON.stringify({
+      error: 'Missing Idempotency-Key header. Provide a unique key for POST, PUT, PATCH, and DELETE requests.'
+    })
+  };
+}
+
+function inProgressResponse(): StoredHttpResponse {
+  return {
+    statusCode: 409,
+    headers: defaultHeaders(),
+    body: JSON.stringify({
+      error: 'Request with this idempotency key is still being processed. Please retry after a short delay.'
+    })
+  };
+}
+
+function errorToResponse(error: unknown): StoredHttpResponse {
+  if (error && typeof error === 'object' && 'statusCode' in error) {
+    return normalizeResponse(error);
+  }
+
+  const message = error instanceof Error ? error.message : 'Internal server error';
+  return {
+    statusCode: 500,
+    headers: defaultHeaders(),
+    body: JSON.stringify({ error: message })
+  };
+}
+
+function attachReplayHeader(response: StoredHttpResponse): StoredHttpResponse {
+  return {
+    ...response,
+    headers: {
+      ...response.headers,
+      'Idempotent-Replayed': 'true'
+    }
+  };
+}
+
+function sanitizeKey(key: string): string {
+  return key.trim().replace(/\s+/g, ' ');
+}
+
+function hashBody(body: string | undefined | null): string | undefined {
+  if (!body) return undefined;
+  return crypto.createHash('sha256').update(body).digest('hex');
+}
+
+export class IdempotencyService {
+  static extractKey(event: any): string | null {
+    const headers = event?.headers || {};
+    for (const name of Object.keys(headers)) {
+      if (name.toLowerCase() === 'idempotency-key') {
+        const value = headers[name];
+        if (typeof value === 'string' && value.trim()) {
+          return sanitizeKey(value);
+        }
+      }
+    }
+
+    // Fallback to X-Request-ID if present to avoid silent duplicates
+    for (const name of Object.keys(headers)) {
+      if (name.toLowerCase() === 'x-request-id') {
+        const value = headers[name];
+        if (typeof value === 'string' && value.trim()) {
+          return sanitizeKey(value);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  static async handleHttp(event: any, operation: () => Promise<any>): Promise<any> {
+    const method = (event?.httpMethod || '').toUpperCase();
+    if (!WRITE_METHODS.has(method)) {
+      return operation();
+    }
+
+    const key = this.extractKey(event);
+    if (!key) {
+      return missingKeyResponse();
+    }
+
+    const metadata = {
+      method,
+      path: event?.path || '',
+      bodyHash: hashBody(event?.body),
+      queryHash: hashBody(JSON.stringify(event?.queryStringParameters || {}))
+    };
+
+    return this.executeWithKey(key, operation, metadata);
+  }
+
+  static async executeWithKey(key: string, operation: () => Promise<any>, metadata?: Record<string, any>): Promise<any> {
+    const normalizedKey = sanitizeKey(key);
+    const partitionKey = buildPartitionKey(normalizedKey);
+
+    const existing = await getRecord(partitionKey);
+    if (existing) {
+      if (existing.status === 'IN_PROGRESS') {
+        return attachReplayHeader(inProgressResponse());
+      }
+
+      if (existing.response) {
+        return attachReplayHeader(deserializeResponse(existing.response));
+      }
+    }
+
+    const now = new Date().toISOString();
+    const baseRecord: IdempotencyRecord = {
+      pk: partitionKey,
+      sk: IDEMPOTENCY_SORT_KEY,
+      key: normalizedKey,
+      status: 'IN_PROGRESS',
+      createdAt: now,
+      updatedAt: now,
+      ttl: ttlSeconds(),
+      ...(metadata ? { metadata } : {})
+    } as IdempotencyRecord;
+
+    try {
+      await putRecord(baseRecord, 'attribute_not_exists(pk)');
+    } catch (error: any) {
+      if (error?.name === 'ConditionalCheckFailedException') {
+        const current = await getRecord(partitionKey);
+        if (current?.response) {
+          return attachReplayHeader(deserializeResponse(current.response));
+        }
+        return attachReplayHeader(inProgressResponse());
+      }
+      throw error;
+    }
+
+    try {
+      const result = await operation();
+      const normalized = normalizeResponse(result);
+
+      const finalRecord: IdempotencyRecord = {
+        ...baseRecord,
+        status: 'COMPLETED',
+        response: normalized,
+        updatedAt: new Date().toISOString(),
+        ttl: ttlSeconds()
+      };
+
+      await putRecord(finalRecord);
+      return normalized;
+    } catch (error) {
+      const errorResponse = errorToResponse(error);
+      const finalRecord: IdempotencyRecord = {
+        ...baseRecord,
+        status: 'FAILED',
+        response: errorResponse,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        updatedAt: new Date().toISOString(),
+        ttl: ttlSeconds()
+      };
+
+      await putRecord(finalRecord);
+      return errorResponse;
+    }
+  }
+}
+
+export default IdempotencyService;


### PR DESCRIPTION
## Summary
- add a shared idempotency service that stores request responses and enforces unique keys for write methods
- wrap checkout, dispute submission, retry, collection, OAuth callback, token refresh, and subscription cancellation handlers with the new service
- ensure responses preserve CORS headers while appending Idempotent-Replayed metadata on duplicate executions

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68deea1c7428832f8e0f02fbd282627b