### PR TITLE
Add exponential backoff retries for Stripe and DynamoDB calls

### DIFF
--- a/src/ai/smartEvidenceCollector.ts
+++ b/src/ai/smartEvidenceCollector.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { z } from 'zod';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { wrapClientSendWithRetry } from '../shared/retry';
 
 // Initialize Stripe client lazily
 let stripe: Stripe | null = null;
@@ -11,16 +12,17 @@ function getStripeClient(): Stripe {
     if (!key || key.includes('placeholder')) {
       throw new Error('Valid Stripe secret key required. Set STRIPE_SECRET environment variable.');
     }
-    stripe = new Stripe(key, { 
-      apiVersion: '2024-06-20' as Stripe.LatestApiVersion 
+    stripe = new Stripe(key, {
+      apiVersion: '2024-06-20' as Stripe.LatestApiVersion,
+      maxNetworkRetries: 3
     });
   }
   return stripe;
 }
 
 // Initialize DynamoDB client
-const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' });
-const docClient = DynamoDBDocumentClient.from(dynamoClient);
+const dynamoClient = wrapClientSendWithRetry(new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' }));
+const docClient = wrapClientSendWithRetry(DynamoDBDocumentClient.from(dynamoClient));
 
 // Evidence bundle schema
 export const EvidenceBundleSchema = z.object({

--- a/src/ce3-engine/ce3Detector.ts
+++ b/src/ce3-engine/ce3Detector.ts
@@ -38,6 +38,7 @@ export class CE3Detector {
   constructor(stripeSecretKey: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
   }
 

--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -34,6 +34,7 @@ export class EvidenceBundler {
   constructor(stripeSecretKey: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
     this.ce3Detector = new CE3Detector(stripeSecretKey);
   }

--- a/src/evidence-collector/smartCollector.ts
+++ b/src/evidence-collector/smartCollector.ts
@@ -77,6 +77,7 @@ export class SmartEvidenceCollector {
   constructor(stripeSecretKey: string, config?: Partial<CollectorConfig>) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
     
     this.config = {

--- a/src/growth-tools/merchantHunter.ts
+++ b/src/growth-tools/merchantHunter.ts
@@ -50,6 +50,7 @@ export class MerchantHunter {
   constructor(stripeSecretKey: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
     
     this.strategies = this.initializeStrategies();

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,6 +1,7 @@
 import { putMerchant } from "../shared/db.js";
 import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
+import { retryWithExponentialBackoff } from "../shared/retry";
 
 export async function handler(event:any){
   const qs = event.queryStringParameters || {};
@@ -15,9 +16,16 @@ export async function handler(event:any){
     code, grant_type: 'authorization_code'
   });
 
-  const r = await fetch('https://connect.stripe.com/oauth/token', {
-    method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
-  });
+  const r = await retryWithExponentialBackoff(
+    () => fetch('https://connect.stripe.com/oauth/token', {
+      method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body
+    }),
+    { retries: 4, baseDelayMs: 300, maxDelayMs: 4000 }
+  );
+  if (!r.ok) {
+    const message = await r.text().catch(() => r.statusText);
+    throw new Error(`Stripe OAuth exchange failed: ${r.status} ${message}`);
+  }
   const json:any = await r.json();
   if(!json.stripe_user_id) return { statusCode:400, body:`oauth failed: ${JSON.stringify(json)}` };
 
@@ -73,7 +81,7 @@ export async function handler(event:any){
 
   // Register webhook endpoint for this connected account
   try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+    const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
     const webhookEndpoint = await stripe.webhookEndpoints.create({
       url: 'https://ket0g0lurh.execute-api.us-east-1.amazonaws.com/webhooks/stripe',
       enabled_events: [

--- a/src/handlers/autoRefreshTokens.ts
+++ b/src/handlers/autoRefreshTokens.ts
@@ -1,6 +1,7 @@
 import { ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { ddb } from "../shared/ddb.js";
 import { putMerchant } from "../shared/db.js";
+import { retryWithExponentialBackoff } from "../shared/retry";
 
 /**
  * Scheduled Lambda to refresh OAuth tokens before they expire
@@ -49,12 +50,19 @@ export async function handler(event: any) {
             client_secret: process.env.STRIPE_SECRET!
           });
           
-          const response = await fetch('https://connect.stripe.com/oauth/token', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body
-          });
-          
+          const response = await retryWithExponentialBackoff(
+            () => fetch('https://connect.stripe.com/oauth/token', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body
+            }),
+            { retries: 4, baseDelayMs: 300, maxDelayMs: 4000 }
+          );
+          if (!response.ok) {
+            const message = await response.text().catch(() => response.statusText);
+            throw new Error(`Stripe OAuth refresh failed: ${response.status} ${message}`);
+          }
+
           const json: any = await response.json();
           
           if (json.access_token) {

--- a/src/handlers/createCheckoutSession.ts
+++ b/src/handlers/createCheckoutSession.ts
@@ -2,7 +2,7 @@ import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
 
 export async function handler(event: any) {
   // Get auth context if user is logged in (optional for checkout)

--- a/src/handlers/disputesHandler.ts
+++ b/src/handlers/disputesHandler.ts
@@ -4,7 +4,7 @@ import { listCases } from '../shared/db.js';
 import { validationMiddleware, commonSchemas } from '../shared/validation.js';
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
 
 interface Dispute {
   id: string;

--- a/src/handlers/getCharge.ts
+++ b/src/handlers/getCharge.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
 
 export async function handler(evt:any){
   // Safely extract stripe_account_id with proper error handling

--- a/src/handlers/getDispute.ts
+++ b/src/handlers/getDispute.ts
@@ -1,7 +1,7 @@
 import Stripe from 'stripe';
 import { getMerchantByAccount, upsertCase } from "../shared/db.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
 
 export async function handler(evt:any){
   const { dispute_id, merchant: { stripe_account_id } } = evt;

--- a/src/handlers/getPaymentIntent.ts
+++ b/src/handlers/getPaymentIntent.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
 
 export async function handler(evt:any){
   const { charge, merchant:{stripe_account_id} } = evt;

--- a/src/handlers/health-minimal.ts
+++ b/src/handlers/health-minimal.ts
@@ -1,4 +1,5 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { wrapClientSendWithRetry } from "../shared/retry";
 
 // Minimal Redis check without heavy imports
 async function checkRedis(): Promise<{ ok: boolean; error?: string }> {
@@ -36,7 +37,7 @@ async function checkRedis(): Promise<{ ok: boolean; error?: string }> {
   });
 }
 
-const dynamo = new DynamoDBClient({});
+const dynamo = wrapClientSendWithRetry(new DynamoDBClient({}));
 
 export const handler = async (_evt: any, ctx: any) => {
   if (ctx && typeof ctx === 'object') {

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,7 +1,8 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { getRedisClient, isRedisReady } from "../cache/redisConnection";
+import { wrapClientSendWithRetry } from "../shared/retry";
 
-const dynamo = new DynamoDBClient({});
+const dynamo = wrapClientSendWithRetry(new DynamoDBClient({}));
 
 const withTimeout = <T>(p: Promise<T>, ms = 350) =>
   Promise.race([

--- a/src/handlers/refreshStripeToken.ts
+++ b/src/handlers/refreshStripeToken.ts
@@ -1,7 +1,7 @@
-import Stripe from 'stripe';
 import { ok, bad } from "../shared/responses.js";
 import { requireAuth } from "../shared/auth.js";
 import { getMerchantByAccount, putMerchant } from "../shared/db.js";
+import { retryWithExponentialBackoff } from "../shared/retry";
 
 /**
  * Refresh Stripe OAuth access token using refresh token
@@ -33,11 +33,18 @@ export async function handler(event: any) {
       client_secret: process.env.STRIPE_SECRET!
     });
     
-    const response = await fetch('https://connect.stripe.com/oauth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body
-    });
+    const response = await retryWithExponentialBackoff(
+      () => fetch('https://connect.stripe.com/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body
+      }),
+      { retries: 4, baseDelayMs: 300, maxDelayMs: 4000 }
+    );
+    if (!response.ok) {
+      const message = await response.text().catch(() => response.statusText);
+      throw new Error(`Stripe OAuth refresh failed: ${response.status} ${message}`);
+    }
     
     const json: any = await response.json();
     

--- a/src/handlers/reportWeekly.ts
+++ b/src/handlers/reportWeekly.ts
@@ -1,8 +1,10 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, ScanCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import { wrapClientSendWithRetry } from "../shared/retry";
 
-const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const dynamoClient = wrapClientSendWithRetry(new DynamoDBClient({}));
+const ddb = wrapClientSendWithRetry(DynamoDBDocumentClient.from(dynamoClient));
 const ses = new SESClient({});
 
 const MERCHANTS = process.env.MERCHANTS_TABLE!;

--- a/src/handlers/retryCase.ts
+++ b/src/handlers/retryCase.ts
@@ -5,7 +5,7 @@ import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
 import Stripe from 'stripe';
 
 const sfn = new SFNClient({});
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
 
 export async function handler(event: any) {
   // REQUIRE AUTHENTICATION

--- a/src/handlers/statsHandler.ts
+++ b/src/handlers/statsHandler.ts
@@ -1,8 +1,9 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { DynamoDBClient, ScanCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
 import Redis from 'ioredis';
+import { wrapClientSendWithRetry } from '../shared/retry';
 
-const dynamodb = new DynamoDBClient({ region: 'us-east-1' });
+const dynamodb = wrapClientSendWithRetry(new DynamoDBClient({ region: 'us-east-1' }));
 const CASES_TABLE = process.env.CASES_TABLE || 'chargeback-autopilot-stripe-prod-CasesTable-1LPIUKCN82FYI';
 const CACHE_TTL = 300; // 5 minutes cache
 

--- a/src/handlers/stripeStageEvidence.ts
+++ b/src/handlers/stripeStageEvidence.ts
@@ -9,14 +9,14 @@ export async function handler(evt:any){
   
   if (merchant?.access_token) {
     // OAuth connected account - use access token directly
-    stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
   } else if (merchant?.stripe_account_id) {
     // Standard connected account - use global secret with stripeAccount header
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
     stripeOptions = { stripeAccount: merchant.stripe_account_id };
   } else {
     // Direct account - use global secret
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
   }
   
   const res = await stripe.disputes.update(dispute.id, { evidence, submit: false }, stripeOptions);

--- a/src/handlers/stripeSubmitEvidence.ts
+++ b/src/handlers/stripeSubmitEvidence.ts
@@ -9,14 +9,14 @@ export async function handler(evt:any){
   
   if (merchant?.access_token) {
     // OAuth connected account - use access token directly
-    stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(merchant.access_token, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
   } else if (merchant?.stripe_account_id) {
     // Standard connected account - use global secret with stripeAccount header
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
     stripeOptions = { stripeAccount: merchant.stripe_account_id };
   } else {
     // Direct account - use global secret
-    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+    stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
   }
   
   const res = await stripe.disputes.update(dispute.id, { submit: true }, stripeOptions);

--- a/src/handlers/submitCase.ts
+++ b/src/handlers/submitCase.ts
@@ -21,7 +21,7 @@ import {
 import { CE3Detector } from "../ce3-engine/ce3Detector.js";
 import { TimingOptimizer } from "../ai-features/timingOptimizer.js";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion:'2025-07-30.basil', maxNetworkRetries: 3 });
 const cloudwatch = new CloudWatch({});
 
 // Helper to publish metrics

--- a/src/handlers/subscriptionManager.ts
+++ b/src/handlers/subscriptionManager.ts
@@ -4,7 +4,7 @@ import { createAuditLog, AuditAction } from "../shared/auditLog.js";
 import { putMerchant, getCase } from "../shared/db.js";
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
 
 // Handle subscription lifecycle events
 export async function handleSubscriptionEvent(event: any, subscriptionEvent: any) {

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -50,7 +50,7 @@ if (process.env.ENABLE_MODEL_UPDATER === 'true') {
   }
 }
 
-const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
 const sfn = new SFNClient({});
 const cloudwatch = new CloudWatch({});
 const WEBHOOK_EVENTS_TABLE = process.env.CASES_TABLE!; // Reuse cases table for webhook events

--- a/src/ml-predictor/featureExtractor.ts
+++ b/src/ml-predictor/featureExtractor.ts
@@ -109,6 +109,7 @@ export class FeatureExtractor {
   constructor(stripeSecretKey: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
     this.cache = new Map();
   }

--- a/src/ml-predictor/modelTrainer.ts
+++ b/src/ml-predictor/modelTrainer.ts
@@ -42,6 +42,7 @@ export class ModelTrainer {
   constructor(stripeSecretKey: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
     
     this.featureExtractor = new FeatureExtractor(stripeSecretKey);

--- a/src/ml-predictor/winPredictor.ts
+++ b/src/ml-predictor/winPredictor.ts
@@ -58,6 +58,7 @@ export class WinPredictor {
   constructor(stripeSecretKey: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     });
     
     this.modelConfig = {

--- a/src/shared/ddb.ts
+++ b/src/shared/ddb.ts
@@ -1,8 +1,11 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { wrapClientSendWithRetry } from "./retry";
 
 const REGION = process.env.AWS_REGION || "us-east-1";
-const client = new DynamoDBClient({ region: REGION });
-export const ddb = DynamoDBDocumentClient.from(client, {
-  marshallOptions: { removeUndefinedValues: true }
-});
+const client = wrapClientSendWithRetry(new DynamoDBClient({ region: REGION }));
+export const ddb = wrapClientSendWithRetry(
+  DynamoDBDocumentClient.from(client, {
+    marshallOptions: { removeUndefinedValues: true }
+  })
+);

--- a/src/shared/retry.ts
+++ b/src/shared/retry.ts
@@ -1,0 +1,102 @@
+export interface RetryOptions {
+  retries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  shouldRetry?: (error: unknown) => boolean;
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
+}
+
+const defaultShouldRetry = (error: any): boolean => {
+  if (!error) return true;
+  const status = error?.statusCode ?? error?.status ?? error?.$metadata?.httpStatusCode;
+  if (typeof status === 'number') {
+    if (status === 429) return true;
+    if (status >= 500) return true;
+    return false;
+  }
+  const code = error?.code ?? error?.name;
+  if (code && typeof code === 'string') {
+    const normalized = code.toLowerCase();
+    if (normalized.includes('timeout') || normalized.includes('throttle')) return true;
+    if (normalized.includes('unavailable') || normalized.includes('expiredtoken')) return true;
+    if (normalized.includes('limit') || normalized.includes('too_many')) return true;
+    if (normalized.includes('error')) return true;
+    return false;
+  }
+  if (error?.type && typeof error.type === 'string') {
+    const t = error.type.toLowerCase();
+    if (t.includes('card_error')) return false;
+    if (t.includes('invalid_request_error')) return false;
+    if (t.includes('authentication_error')) return false;
+    return true;
+  }
+  return true;
+};
+
+export const retryWithExponentialBackoff = async <T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> => {
+  const {
+    retries = 3,
+    baseDelayMs = 200,
+    maxDelayMs = 2000,
+    shouldRetry = defaultShouldRetry,
+    onRetry
+  } = options;
+
+  let attempt = 0;
+  // attempt counts retries after first failure; total attempts = retries + 1
+  // we keep last error to throw if all retries exhausted
+  let lastError: unknown;
+
+  while (attempt <= retries) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt === retries || !shouldRetry(error)) {
+        throw error;
+      }
+      const delay = Math.min(
+        maxDelayMs,
+        Math.round(baseDelayMs * Math.pow(2, attempt) + Math.random() * baseDelayMs)
+      );
+      if (typeof onRetry === 'function') {
+        try {
+          onRetry(error, attempt + 1, delay);
+        } catch (hookError) {
+          console.warn('Retry hook error', hookError);
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, delay));
+      attempt += 1;
+    }
+  }
+
+  throw lastError ?? new Error('Retry operation failed without error context');
+};
+
+export const wrapClientSendWithRetry = <T extends { send: (command: any) => Promise<any> }>(
+  client: T,
+  options: RetryOptions = {}
+): T => {
+  const marker = '__retryWrapped';
+  if ((client as any)[marker]) {
+    return client;
+  }
+  const send = client.send.bind(client);
+  const retryOptions: RetryOptions = {
+    retries: 3,
+    baseDelayMs: 200,
+    maxDelayMs: 2500,
+    ...options
+  };
+  client.send = ((command: any) =>
+    retryWithExponentialBackoff(() => send(command), retryOptions)
+  ) as typeof client.send;
+  (client as any)[marker] = true;
+  return client;
+};
+
+export const shouldRetry = defaultShouldRetry;

--- a/src/shared/webhookIdempotency.ts
+++ b/src/shared/webhookIdempotency.ts
@@ -1,8 +1,9 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { wrapClientSendWithRetry } from './retry';
 
-const client = new DynamoDBClient({});
-const ddb = DynamoDBDocumentClient.from(client);
+const client = wrapClientSendWithRetry(new DynamoDBClient({}));
+const ddb = wrapClientSendWithRetry(DynamoDBDocumentClient.from(client));
 
 const IDEMPOTENCY_TABLE = process.env.CASES_TABLE || 'CasesTable';
 const IDEMPOTENCY_TTL_HOURS = 24;

--- a/src/shared/webhookSecrets.ts
+++ b/src/shared/webhookSecrets.ts
@@ -1,9 +1,10 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { wrapClientSendWithRetry } from './retry';
 
-const client = new DynamoDBClient({});
-const ddb = DynamoDBDocumentClient.from(client);
+const client = wrapClientSendWithRetry(new DynamoDBClient({}));
+const ddb = wrapClientSendWithRetry(DynamoDBDocumentClient.from(client));
 const ssm = new SSMClient({});
 
 const MERCHANTS_TABLE = process.env.MERCHANTS_TABLE || 'MerchantsTable';
@@ -83,7 +84,7 @@ export async function validateWebhookSignature(
   accountId?: string
 ): Promise<boolean> {
   const Stripe = require('stripe');
-  const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+  const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil', maxNetworkRetries: 3 });
   
   try {
     // Get the appropriate webhook secret

--- a/stripedshield-app/app/api/billing/checkout/route.ts
+++ b/stripedshield-app/app/api/billing/checkout/route.ts
@@ -11,8 +11,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { 
-      apiVersion: '2025-07-30.basil' 
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     })
     
     // Get price ID from request or use default founder price

--- a/stripedshield-app/app/api/billing/portal/route.ts
+++ b/stripedshield-app/app/api/billing/portal/route.ts
@@ -13,8 +13,9 @@ export async function POST() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { 
-      apiVersion: '2025-07-30.basil' 
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     })
     
     // Try to find customer by email

--- a/stripedshield-app/app/api/stripe/connect-simple/route.ts
+++ b/stripedshield-app/app/api/stripe/connect-simple/route.ts
@@ -4,7 +4,8 @@ import Stripe from 'stripe'
 
 export async function GET(req: NextRequest) {
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-    apiVersion: '2025-07-30.basil'
+    apiVersion: '2025-07-30.basil',
+    maxNetworkRetries: 3
   })
 
   try {
@@ -47,7 +48,8 @@ export async function POST(req: NextRequest) {
   const sig = req.headers.get('stripe-signature')!
   
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-    apiVersion: '2025-07-30.basil'
+    apiVersion: '2025-07-30.basil',
+    maxNetworkRetries: 3
   })
 
   try {

--- a/stripedshield-app/app/api/stripe/connect/callback/route.ts
+++ b/stripedshield-app/app/api/stripe/connect/callback/route.ts
@@ -9,8 +9,9 @@ export async function GET(req: NextRequest) {
   }
   
   try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { 
-      apiVersion: '2025-07-30.basil' 
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2025-07-30.basil',
+      maxNetworkRetries: 3
     })
     
     const response = await stripe.oauth.token({


### PR DESCRIPTION
## Summary
- add a shared exponential backoff helper and wrap DynamoDB clients so sends are retried automatically
- enable Stripe SDK network retries and guard OAuth token exchanges with backoff-based fetch helpers
- propagate the retry-enabled clients across dispute handlers, collectors, and Next.js API routes

## Testing
- npm run build *(fails: TypeScript error in src/handlers/buildEvidence.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dee9f704fc832f99bdccc35ecfee8d