### PR TITLE
Support connected account feature extraction

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 import { StartExecutionCommand, SFNClient } from "@aws-sdk/client-sfn";
-import { upsertCase } from "../shared/db.js";
+import { upsertCase, getMerchantByAccount } from "../shared/db.js";
 import { getMerchantWinRate } from "../shared/db-helpers.js";
 import { handleSubscriptionEvent } from "./subscriptionManager.js";
 import { WebhookIdempotencyService } from "../shared/webhookIdempotency.js";
@@ -304,6 +304,16 @@ export async function handler(event:any){
 
   if(evt.type === 'charge.dispute.created' || evt.type === 'charge.dispute.updated'){
     const dispute = evt.data.object as Stripe.Dispute;
+
+    let merchantAccessToken: string | undefined;
+    if (eventAccount) {
+      try {
+        const merchantRecord = await getMerchantByAccount(eventAccount);
+        merchantAccessToken = merchantRecord?.access_token;
+      } catch (error) {
+        console.error('Failed to load merchant credentials for feature extraction:', error);
+      }
+    }
     
     // Initialize AI analysis
     let aiAnalysis: DisputeAnalysis | null = null;
@@ -387,7 +397,10 @@ export async function handler(event:any){
       
       try {
         // 1. Extract all features (34+ features)
-        const featureExtractor = new FeatureExtractor(process.env.STRIPE_SECRET!);
+        const featureExtractor = new FeatureExtractor(
+          merchantAccessToken || process.env.STRIPE_SECRET!,
+          merchantAccessToken ? undefined : eventAccount
+        );
         const features = await featureExtractor.extractAllFeatures(dispute);
         
         // 2. Get our original prediction (if exists)

--- a/src/ml-predictor/featureExtractor.ts
+++ b/src/ml-predictor/featureExtractor.ts
@@ -105,12 +105,24 @@ export interface EvidenceFeatures {
 export class FeatureExtractor {
   private stripe: Stripe;
   private cache: Map<string, any>;
-  
-  constructor(stripeSecretKey: string) {
+  private stripeAccount?: string;
+
+  constructor(stripeSecretKey: string, stripeAccount?: string) {
     this.stripe = new Stripe(stripeSecretKey, {
       apiVersion: '2025-07-30.basil',
     });
+    this.stripeAccount = stripeAccount;
     this.cache = new Map();
+  }
+
+  private getRequestOptions(): Stripe.RequestOptions | undefined {
+    if (!this.stripeAccount) {
+      return undefined;
+    }
+
+    return {
+      stripeAccount: this.stripeAccount,
+    };
   }
   
   async extractAllFeatures(
@@ -154,7 +166,11 @@ export class FeatureExtractor {
     }
     
     try {
-      const charge = await this.stripe.charges.retrieve(chargeId);
+      const charge = await this.stripe.charges.retrieve(
+        chargeId,
+        undefined,
+        this.getRequestOptions()
+      );
       this.cache.set(cacheKey, charge);
       return charge;
     } catch (error) {
@@ -170,7 +186,11 @@ export class FeatureExtractor {
     }
     
     try {
-      const pi = await this.stripe.paymentIntents.retrieve(piId);
+      const pi = await this.stripe.paymentIntents.retrieve(
+        piId,
+        undefined,
+        this.getRequestOptions()
+      );
       this.cache.set(cacheKey, pi);
       return pi;
     } catch (error) {
@@ -217,11 +237,18 @@ export class FeatureExtractor {
     
     if (charge?.customer) {
       try {
-        customer = await this.stripe.customers.retrieve(charge.customer as string) as Stripe.Customer;
-        const chargesList = await this.stripe.charges.list({
-          customer: charge.customer as string,
-          limit: 100
-        });
+        customer = await this.stripe.customers.retrieve(
+          charge.customer as string,
+          undefined,
+          this.getRequestOptions()
+        ) as Stripe.Customer;
+        const chargesList = await this.stripe.charges.list(
+          {
+            customer: charge.customer as string,
+            limit: 100
+          },
+          this.getRequestOptions()
+        );
         customerCharges = chargesList.data;
       } catch (error) {
         console.error('Failed to get customer data:', error);

--- a/tests/__mocks__/stripe.ts
+++ b/tests/__mocks__/stripe.ts
@@ -1,0 +1,139 @@
+declare const jest: any;
+
+type Resource = 'charges' | 'paymentIntents' | 'customers';
+
+type RequestLogEntry = {
+  method: string;
+  id?: string;
+  params?: any;
+  options?: any;
+  apiKey: string;
+};
+
+const mockState: {
+  charges: Map<string, any>;
+  paymentIntents: Map<string, any>;
+  customers: Map<string, any>;
+  chargesList: any[];
+  requestLog: RequestLogEntry[];
+} = {
+  charges: new Map(),
+  paymentIntents: new Map(),
+  customers: new Map(),
+  chargesList: [],
+  requestLog: [],
+};
+
+function normalizeArgs(params?: any, options?: any) {
+  if (params && !options && typeof params === 'object' && 'stripeAccount' in params) {
+    return { params: undefined, options: params };
+  }
+  return { params, options };
+}
+
+export function __setMockResponse(resource: Resource, id: string, data: any) {
+  switch (resource) {
+    case 'charges':
+      mockState.charges.set(id, data);
+      break;
+    case 'paymentIntents':
+      mockState.paymentIntents.set(id, data);
+      break;
+    case 'customers':
+      mockState.customers.set(id, data);
+      break;
+  }
+}
+
+export function __setChargesList(data: any[]) {
+  mockState.chargesList = data;
+}
+
+export function __resetMockState() {
+  mockState.charges.clear();
+  mockState.paymentIntents.clear();
+  mockState.customers.clear();
+  mockState.chargesList = [];
+  mockState.requestLog = [];
+}
+
+export function __getRequestLog(): RequestLogEntry[] {
+  return mockState.requestLog;
+}
+
+export default class StripeMock {
+  private apiKey: string;
+
+  charges: {
+    retrieve: ReturnType<typeof jest.fn>;
+    list: ReturnType<typeof jest.fn>;
+  };
+
+  paymentIntents: {
+    retrieve: ReturnType<typeof jest.fn>;
+  };
+
+  customers: {
+    retrieve: ReturnType<typeof jest.fn>;
+  };
+
+  constructor(apiKey: string, _config?: any) {
+    this.apiKey = apiKey;
+
+    this.charges = {
+      retrieve: jest.fn(async (id: string, params?: any, options?: any) => {
+        const normalized = normalizeArgs(params, options);
+        mockState.requestLog.push({
+          method: 'charges.retrieve',
+          id,
+          params: normalized.params,
+          options: normalized.options,
+          apiKey: this.apiKey,
+        });
+        return mockState.charges.get(id) ?? { id, object: 'charge' };
+      }),
+      list: jest.fn(async (params?: any, options?: any) => {
+        const normalized = normalizeArgs(params, options);
+        mockState.requestLog.push({
+          method: 'charges.list',
+          params: normalized.params,
+          options: normalized.options,
+          apiKey: this.apiKey,
+        });
+        return {
+          object: 'list',
+          data: mockState.chargesList,
+          has_more: false,
+        };
+      }),
+    };
+
+    this.paymentIntents = {
+      retrieve: jest.fn(async (id: string, params?: any, options?: any) => {
+        const normalized = normalizeArgs(params, options);
+        mockState.requestLog.push({
+          method: 'paymentIntents.retrieve',
+          id,
+          params: normalized.params,
+          options: normalized.options,
+          apiKey: this.apiKey,
+        });
+        return mockState.paymentIntents.get(id) ?? { id, object: 'payment_intent' };
+      }),
+    };
+
+    this.customers = {
+      retrieve: jest.fn(async (id: string, params?: any, options?: any) => {
+        const normalized = normalizeArgs(params, options);
+        mockState.requestLog.push({
+          method: 'customers.retrieve',
+          id,
+          params: normalized.params,
+          options: normalized.options,
+          apiKey: this.apiKey,
+        });
+        return mockState.customers.get(id) ?? { id, object: 'customer' };
+      }),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- allow the ML feature extractor to accept an optional connected account identifier and forward it to every Stripe request
- load the merchant access token in the Stripe webhook handler before extracting features so connected accounts use the right credentials
- add a Stripe Jest mock that records request options for connected-account scenarios and extend the evidence package type used during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded911c048832f87eae2b34d5ef316