### PR TITLE
Enrich dispute case records with customer metadata

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -304,53 +304,108 @@ export async function handler(event:any){
 
   if(evt.type === 'charge.dispute.created' || evt.type === 'charge.dispute.updated'){
     const dispute = evt.data.object as Stripe.Dispute;
-    
+
+    let charge: Stripe.Charge | null = null;
+    let paymentIntent: Stripe.PaymentIntent | null = null;
+
+    try {
+      if (dispute.charge) {
+        charge = await stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount });
+      }
+
+      const paymentIntentId = typeof dispute.payment_intent === 'string'
+        ? dispute.payment_intent
+        : typeof charge?.payment_intent === 'string'
+          ? charge.payment_intent
+          : (charge?.payment_intent as Stripe.PaymentIntent | null)?.id || null;
+
+      if (paymentIntentId) {
+        paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId, { stripeAccount: eventAccount });
+      }
+    } catch (error) {
+      console.error('Failed to load charge/payment intent for dispute:', dispute.id, error);
+    }
+
+    const customerId = typeof charge?.customer === 'string'
+      ? charge.customer
+      : (charge?.customer as Stripe.Customer | null)?.id
+        || (typeof paymentIntent?.customer === 'string'
+          ? paymentIntent.customer
+          : (paymentIntent?.customer as Stripe.Customer | null)?.id
+        )
+        || null;
+
+    const orderId = charge?.metadata?.order_id
+      || charge?.metadata?.orderId
+      || paymentIntent?.metadata?.order_id
+      || paymentIntent?.metadata?.orderId
+      || null;
+
+    const shippingAddress = charge?.shipping?.address || paymentIntent?.shipping?.address || null;
+
+    const refunded = charge ? (charge.refunded || charge.amount_refunded > 0) : false;
+
+    const refundTimestamps = ((charge?.refunds?.data || [])
+      .map(refund => refund.created ? new Date(refund.created * 1000).toISOString() : null)
+      .filter((timestamp): timestamp is string => Boolean(timestamp)));
+
     // Initialize AI analysis
     let aiAnalysis: DisputeAnalysis | null = null;
     let riskLevel = 'medium';
-    
+
     // Only run AI if enabled via feature flag
     if (process.env.AI_ENABLED === 'true' && isAIEnabled()) {
       // Analyze dispute with new AI module when created
       if(evt.type === 'charge.dispute.created'){
         try {
-          // Get charge data for analysis
-          const charge = await stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount });
-          
-          // Quick risk assessment first
-          riskLevel = quickAssessRisk(dispute);
-          
-          // Full AI analysis with REAL merchant win rate
-          const merchantWinRate = eventAccount ? await getMerchantWinRate(eventAccount) : 0.5;
-          aiAnalysis = await analyzeDispute({
-            dispute,
-            charge,
-            merchantWinRate // REAL data from database
-          });
-          
-          console.log('[AI] Dispute Analysis:', {
-            disputeId: dispute.id,
-            weaknesses: aiAnalysis.weaknesses.length,
-            bestEvidence: aiAnalysis.bestEvidence.length,
-            riskLevel: aiAnalysis.riskLevel,
-            estimatedWinProbability: aiAnalysis.estimatedWinProbability
-          });
-          
-          // Publish metrics
-          await publishMetric('ai_analyzed', 1);
-          if (aiAnalysis.estimatedWinProbability) {
-            await publishMetric('ai_win_probability', aiAnalysis.estimatedWinProbability * 100, 'Percent');
+          if (!charge && dispute.charge) {
+            charge = await stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount });
           }
-          
+
+          if (charge) {
+            // Quick risk assessment first
+            riskLevel = quickAssessRisk(dispute);
+
+            // Full AI analysis with REAL merchant win rate
+            const merchantWinRate = eventAccount ? await getMerchantWinRate(eventAccount) : 0.5;
+            aiAnalysis = await analyzeDispute({
+              dispute,
+              charge,
+              merchantWinRate // REAL data from database
+            });
+
+            console.log('[AI] Dispute Analysis:', {
+              disputeId: dispute.id,
+              weaknesses: aiAnalysis.weaknesses.length,
+              bestEvidence: aiAnalysis.bestEvidence.length,
+              riskLevel: aiAnalysis.riskLevel,
+              estimatedWinProbability: aiAnalysis.estimatedWinProbability
+            });
+
+            // Publish metrics
+            await publishMetric('ai_analyzed', 1);
+            if (aiAnalysis.estimatedWinProbability) {
+              await publishMetric('ai_win_probability', aiAnalysis.estimatedWinProbability * 100, 'Percent');
+            }
+          } else {
+            console.warn('Unable to load charge for dispute analysis:', dispute.id);
+          }
+
         } catch (error) {
           console.error('[AI] Analysis failed:', error);
           await publishMetric('ai_error', 1);
         }
       }
     }
-    
+
     // Store case with AI analysis
     await upsertCase(eventAccount!, dispute, {
+      customer_id: customerId,
+      order_id: orderId,
+      shipping_address: shippingAddress,
+      refunded,
+      refund_timestamps: refundTimestamps,
+      payment_intent_id: paymentIntent?.id || undefined,
       aiAnalysis: aiAnalysis ? {
         weaknesses: aiAnalysis.weaknesses,
         bestEvidence: aiAnalysis.bestEvidence,

--- a/src/shared/db-helpers.ts
+++ b/src/shared/db-helpers.ts
@@ -57,6 +57,10 @@ export async function getMerchantWinRate(merchantId: string, daysPeriod = 180): 
  * @returns Number of prior transactions
  */
 export async function getCustomerTransactionCount(merchantId: string, customerId: string): Promise<number> {
+  if (!customerId) {
+    console.warn('[DB] Missing customerId for transaction count lookup');
+    return 0;
+  }
   try {
     const response = await ddb.send(new QueryCommand({
       TableName: CASES,
@@ -84,6 +88,10 @@ export async function getCustomerTransactionCount(merchantId: string, customerId
  * @returns Days since first transaction
  */
 export async function getCustomerTenureDays(merchantId: string, customerId: string): Promise<number> {
+  if (!customerId) {
+    console.warn('[DB] Missing customerId for tenure lookup');
+    return 0;
+  }
   try {
     const response = await ddb.send(new QueryCommand({
       TableName: CASES,
@@ -120,6 +128,10 @@ export async function getCustomerTenureDays(merchantId: string, customerId: stri
  * @returns Total number of orders
  */
 export async function getCustomerOrderCount(merchantId: string, customerId: string): Promise<number> {
+  if (!customerId) {
+    console.warn('[DB] Missing customerId for order count lookup');
+    return 0;
+  }
   try {
     const response = await ddb.send(new QueryCommand({
       TableName: CASES,
@@ -148,9 +160,13 @@ export async function getCustomerOrderCount(merchantId: string, customerId: stri
  * @returns Number of refunds in last 90 days
  */
 export async function getCustomerRefundsLast90Days(merchantId: string, customerId: string): Promise<number> {
+  if (!customerId) {
+    console.warn('[DB] Missing customerId for refund lookup');
+    return 0;
+  }
   try {
     const ninetyDaysAgo = Math.floor((Date.now() - (90 * 24 * 60 * 60 * 1000)) / 1000);
-    
+
     const response = await ddb.send(new QueryCommand({
       TableName: CASES,
       KeyConditionExpression: "pk = :pk",
@@ -180,10 +196,14 @@ export async function getCustomerRefundsLast90Days(merchantId: string, customerI
  * @returns Object with eligibility status and matched transactions
  */
 export async function checkCE3Eligibility(
-  merchantId: string, 
-  customerId: string, 
+  merchantId: string,
+  customerId: string,
   chargeId: string
 ): Promise<{ eligible: boolean; priorTransactionCount: number; matchedElements: string[] }> {
+  if (!customerId) {
+    console.warn('[DB] Missing customerId for CE3 eligibility check');
+    return { eligible: false, priorTransactionCount: 0, matchedElements: [] };
+  }
   try {
     // CE3.0 requires 2+ prior undisputed transactions (120-365 days old)
     const oneYearAgo = Math.floor((Date.now() - (365 * 24 * 60 * 60 * 1000)) / 1000);

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -25,16 +25,47 @@ export async function getMerchantByAccount(stripe_account_id:string){
 
 export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
   const now = Math.floor(Date.now()/1000);
+
+  const {
+    customer_id = null,
+    order_id = null,
+    shipping_address = null,
+    refunded = false,
+    refund_timestamps = [],
+    dispute_status = dispute.status,
+    payment_intent_id: extrasPaymentIntentId,
+    ...restExtras
+  } = extras || {};
+
+  const normalizedPaymentIntentId = extrasPaymentIntentId
+    ?? (typeof dispute.payment_intent === 'string'
+      ? dispute.payment_intent
+      : (dispute.payment_intent && typeof dispute.payment_intent.id === 'string'
+        ? dispute.payment_intent.id
+        : null));
+
+  const normalizedRefundTimestamps = Array.isArray(refund_timestamps)
+    ? refund_timestamps
+    : refund_timestamps
+      ? [refund_timestamps]
+      : [];
+
   const item = {
     pk: `MERCHANT#${merchantId}`,
     sk: `CASE#${dispute.id}`,
     dispute_id: dispute.id,
-    charge_id: dispute.charge,
-    payment_intent_id: dispute.payment_intent,
+    charge_id: typeof dispute.charge === 'string' ? dispute.charge : dispute.charge?.id || null,
+    payment_intent_id: normalizedPaymentIntentId,
     amount_cents: dispute.amount,
     currency: dispute.currency,
     reason: dispute.reason,
     status: dispute.status,
+    dispute_status,
+    customer_id,
+    order_id,
+    shipping_address,
+    refunded,
+    refund_timestamps: normalizedRefundTimestamps,
     created_at_epoch: dispute.created || now,
     updated_at_epoch: now,
     result_at_epoch: (['won','lost'].includes(dispute.status) ? now : undefined),
@@ -43,7 +74,7 @@ export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
     gsi1_sk: dispute.evidence_details?.due_by || 0,
     gsi2_pk: `STATUS#${dispute.status}`,
     gsi2_sk: dispute.evidence_details?.due_by || 0,
-    ...extras
+    ...restExtras
   };
   await ddb.send(new PutCommand({ TableName: CASES, Item: item }));
   return item;


### PR DESCRIPTION
## Summary
- load disputed charges and payment intents during webhook processing to capture customer, order, shipping, and refund metadata when upserting cases
- normalize case storage defaults for new metadata fields and guard helper queries against missing customer identifiers
- expose a fraud warning flag on evidence packages so downstream handlers can annotate ML-driven fraud detection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded90f6a7c832f88578b07a1b05c76