### PR TITLE
Capture Stripe customer IDs when storing dispute cases

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/webhookStripe.ts
+++ b/src/handlers/webhookStripe.ts
@@ -304,7 +304,58 @@ export async function handler(event:any){
 
   if(evt.type === 'charge.dispute.created' || evt.type === 'charge.dispute.updated'){
     const dispute = evt.data.object as Stripe.Dispute;
-    
+
+    const requestOptions = eventAccount ? { stripeAccount: eventAccount } : undefined;
+    let charge: Stripe.Charge | null = null;
+    let paymentIntent: Stripe.PaymentIntent | null = null;
+    let customerId: string | null = null;
+
+    if (typeof dispute.charge === 'string') {
+      try {
+        charge = await stripe.charges.retrieve(dispute.charge as string, undefined, requestOptions);
+        const chargeCustomer = charge.customer as Stripe.Customer | string | null | undefined;
+        if (typeof chargeCustomer === 'string') {
+          customerId = chargeCustomer;
+        } else if (chargeCustomer) {
+          customerId = chargeCustomer.id;
+        }
+        if (!paymentIntent && typeof charge.payment_intent === 'string') {
+          try {
+            paymentIntent = await stripe.paymentIntents.retrieve(charge.payment_intent, undefined, requestOptions);
+          } catch (error) {
+            console.error('Failed to retrieve payment intent from charge context:', error);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to retrieve charge for dispute:', error);
+      }
+    }
+
+    if (!customerId && typeof (dispute as any).customer === 'string') {
+      customerId = (dispute as any).customer;
+    }
+
+    if (!customerId && typeof dispute.payment_intent === 'string') {
+      try {
+        paymentIntent = paymentIntent || await stripe.paymentIntents.retrieve(dispute.payment_intent as string, undefined, requestOptions);
+        const piCustomer = paymentIntent.customer as Stripe.Customer | string | null | undefined;
+        if (typeof piCustomer === 'string') {
+          customerId = piCustomer;
+        } else if (piCustomer) {
+          customerId = piCustomer.id;
+        }
+        if (!charge && typeof paymentIntent.latest_charge === 'string') {
+          try {
+            charge = await stripe.charges.retrieve(paymentIntent.latest_charge, undefined, requestOptions);
+          } catch (error) {
+            console.error('Failed to retrieve latest charge from payment intent:', error);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to retrieve payment intent for dispute:', error);
+      }
+    }
+
     // Initialize AI analysis
     let aiAnalysis: DisputeAnalysis | null = null;
     let riskLevel = 'medium';
@@ -314,32 +365,41 @@ export async function handler(event:any){
       // Analyze dispute with new AI module when created
       if(evt.type === 'charge.dispute.created'){
         try {
-          // Get charge data for analysis
-          const charge = await stripe.charges.retrieve(dispute.charge as string, { stripeAccount: eventAccount });
-          
           // Quick risk assessment first
           riskLevel = quickAssessRisk(dispute);
+
+          if (!charge && typeof dispute.charge === 'string') {
+            try {
+              charge = await stripe.charges.retrieve(dispute.charge as string, undefined, requestOptions);
+            } catch (error) {
+              console.error('Failed to retrieve charge for AI analysis:', error);
+            }
+          }
+
+          if (charge) {
+            // Full AI analysis with REAL merchant win rate
+            const merchantWinRate = eventAccount ? await getMerchantWinRate(eventAccount) : 0.5;
+            aiAnalysis = await analyzeDispute({
+              dispute,
+              charge,
+              merchantWinRate // REAL data from database
+            });
+          }
           
-          // Full AI analysis with REAL merchant win rate
-          const merchantWinRate = eventAccount ? await getMerchantWinRate(eventAccount) : 0.5;
-          aiAnalysis = await analyzeDispute({
-            dispute,
-            charge,
-            merchantWinRate // REAL data from database
-          });
-          
-          console.log('[AI] Dispute Analysis:', {
-            disputeId: dispute.id,
-            weaknesses: aiAnalysis.weaknesses.length,
-            bestEvidence: aiAnalysis.bestEvidence.length,
-            riskLevel: aiAnalysis.riskLevel,
-            estimatedWinProbability: aiAnalysis.estimatedWinProbability
-          });
-          
-          // Publish metrics
-          await publishMetric('ai_analyzed', 1);
-          if (aiAnalysis.estimatedWinProbability) {
-            await publishMetric('ai_win_probability', aiAnalysis.estimatedWinProbability * 100, 'Percent');
+          if (aiAnalysis) {
+            console.log('[AI] Dispute Analysis:', {
+              disputeId: dispute.id,
+              weaknesses: aiAnalysis.weaknesses.length,
+              bestEvidence: aiAnalysis.bestEvidence.length,
+              riskLevel: aiAnalysis.riskLevel,
+              estimatedWinProbability: aiAnalysis.estimatedWinProbability
+            });
+
+            // Publish metrics
+            await publishMetric('ai_analyzed', 1);
+            if (aiAnalysis.estimatedWinProbability) {
+              await publishMetric('ai_win_probability', aiAnalysis.estimatedWinProbability * 100, 'Percent');
+            }
           }
           
         } catch (error) {
@@ -360,7 +420,8 @@ export async function handler(event:any){
         recommendedActions: aiAnalysis.recommendedActions
       } : null,
       riskLevel,
-      aiEnhanced: !!aiAnalysis
+      aiEnhanced: !!aiAnalysis,
+      customer_id: customerId
     });
     
     if(evt.type === 'charge.dispute.created'){

--- a/src/scripts/backfillCustomerIds.ts
+++ b/src/scripts/backfillCustomerIds.ts
@@ -1,0 +1,138 @@
+import Stripe from 'stripe';
+import { ScanCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb } from '../shared/ddb.js';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET!, { apiVersion: '2025-07-30.basil' });
+const CASES_TABLE = process.env.CASES_TABLE!;
+
+interface CaseItem {
+  pk: string;
+  sk: string;
+  charge_id?: string | null;
+  payment_intent_id?: string | null;
+  customer_id?: string | null;
+  [key: string]: any;
+}
+
+async function fetchCustomerId(item: CaseItem): Promise<string | null> {
+  if (item.customer_id) {
+    return item.customer_id;
+  }
+
+  let requestOptions: Stripe.RequestOptions | undefined;
+  if (item.pk?.startsWith('MERCHANT#')) {
+    const merchantId = item.pk.replace('MERCHANT#', '');
+    if (merchantId.startsWith('acct_')) {
+      requestOptions = { stripeAccount: merchantId };
+    }
+  }
+
+  if (item.charge_id) {
+    try {
+      const charge = await stripe.charges.retrieve(item.charge_id, undefined, requestOptions);
+      const chargeCustomer = charge.customer as Stripe.Customer | string | null | undefined;
+      if (typeof chargeCustomer === 'string') {
+        return chargeCustomer;
+      }
+      if (chargeCustomer) {
+        return chargeCustomer.id;
+      }
+      if (typeof charge.payment_intent === 'string') {
+        const pi = await stripe.paymentIntents.retrieve(charge.payment_intent, undefined, requestOptions);
+        const piCustomer = pi.customer as Stripe.Customer | string | null | undefined;
+        if (typeof piCustomer === 'string') {
+          return piCustomer;
+        }
+        if (piCustomer) {
+          return piCustomer.id;
+        }
+      }
+    } catch (error) {
+      console.error(`Failed to retrieve charge ${item.charge_id}:`, error);
+    }
+  }
+
+  if (item.payment_intent_id) {
+    try {
+      const pi = await stripe.paymentIntents.retrieve(item.payment_intent_id, undefined, requestOptions);
+      const piCustomer = pi.customer as Stripe.Customer | string | null | undefined;
+      if (typeof piCustomer === 'string') {
+        return piCustomer;
+      }
+      if (piCustomer) {
+        return piCustomer.id;
+      }
+      if (typeof pi.latest_charge === 'string') {
+        try {
+          const charge = await stripe.charges.retrieve(pi.latest_charge, undefined, requestOptions);
+          const chargeCustomer = charge.customer as Stripe.Customer | string | null | undefined;
+          if (typeof chargeCustomer === 'string') {
+            return chargeCustomer;
+          }
+          if (chargeCustomer) {
+            return chargeCustomer.id;
+          }
+        } catch (error) {
+          console.error(`Failed to retrieve latest charge ${pi.latest_charge} for payment intent ${pi.id}:`, error);
+        }
+      }
+    } catch (error) {
+      console.error(`Failed to retrieve payment intent ${item.payment_intent_id}:`, error);
+    }
+  }
+
+  return null;
+}
+
+async function backfillBatch(items: CaseItem[]) {
+  for (const item of items) {
+    const customerId = await fetchCustomerId(item);
+    if (!customerId) {
+      continue;
+    }
+
+    if (item.customer_id === customerId) {
+      continue;
+    }
+
+    const updatedItem = { ...item, customer_id: customerId };
+    await ddb.send(new PutCommand({
+      TableName: CASES_TABLE,
+      Item: updatedItem
+    }));
+    console.log(`Backfilled customer ${customerId} for ${item.pk}#${item.sk}`);
+  }
+}
+
+export async function backfillCustomerIds() {
+  let ExclusiveStartKey: Record<string, any> | undefined;
+
+  do {
+    const response = await ddb.send(new ScanCommand({
+      TableName: CASES_TABLE,
+      ExclusiveStartKey,
+      FilterExpression: 'attribute_not_exists(customer_id) OR customer_id = :empty',
+      ExpressionAttributeValues: {
+        ':empty': null
+      }
+    }));
+
+    const items = (response.Items as CaseItem[] | undefined) || [];
+    if (items.length > 0) {
+      await backfillBatch(items);
+    }
+
+    ExclusiveStartKey = response.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+}
+
+if (require.main === module) {
+  backfillCustomerIds()
+    .then(() => {
+      console.log('Customer ID backfill complete');
+    })
+    .catch((error) => {
+      console.error('Customer ID backfill failed', error);
+      process.exitCode = 1;
+    });
+}

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -25,12 +25,19 @@ export async function getMerchantByAccount(stripe_account_id:string){
 
 export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
   const now = Math.floor(Date.now()/1000);
+  const { customer_id: providedCustomerId, ...restExtras } = extras || {};
+  const disputeCustomer = typeof dispute.customer === 'string'
+    ? dispute.customer
+    : dispute.customer?.id;
+  const customer_id = providedCustomerId ?? disputeCustomer ?? null;
+
   const item = {
     pk: `MERCHANT#${merchantId}`,
     sk: `CASE#${dispute.id}`,
     dispute_id: dispute.id,
     charge_id: dispute.charge,
     payment_intent_id: dispute.payment_intent,
+    customer_id,
     amount_cents: dispute.amount,
     currency: dispute.currency,
     reason: dispute.reason,
@@ -43,7 +50,7 @@ export async function upsertCase(merchantId:string, dispute:any, extras:any={}){
     gsi1_sk: dispute.evidence_details?.due_by || 0,
     gsi2_pk: `STATUS#${dispute.status}`,
     gsi2_sk: dispute.evidence_details?.due_by || 0,
-    ...extras
+    ...restExtras
   };
   await ddb.send(new PutCommand({ TableName: CASES, Item: item }));
   return item;


### PR DESCRIPTION
## Summary
- capture customer identifiers for dispute webhooks and persist them in case records
- ensure upsertCase always writes a customer_id field and add a script to backfill legacy items
- allow evidence packages to flag fraud warnings to satisfy build-time typing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded637ca4c832f8fca389bccc6b3ee