### PR TITLE
Fix merchant upserts to preserve OAuth credentials

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {

--- a/src/handlers/authStripeCallback.ts
+++ b/src/handlers/authStripeCallback.ts
@@ -1,4 +1,6 @@
+import { PutCommand } from "@aws-sdk/lib-dynamodb";
 import { putMerchant } from "../shared/db.js";
+import { ddb } from "../shared/ddb.js";
 import Stripe from 'stripe';
 import { createAuditLog, AuditAction, auditFailure } from "../shared/auditLog.js";
 
@@ -42,7 +44,7 @@ export async function handler(event:any){
   }
 
   // Save all OAuth data to DynamoDB
-  await putMerchant({ 
+  await putMerchant({
     merchant_id,
     stripe_account_id: merchant_id,
     access_token, // CRITICAL: Save this for API calls
@@ -54,6 +56,22 @@ export async function handler(event:any){
     firebase_uid, // Link to Firebase user
     oauth_connected_at: new Date().toISOString()
   });
+
+  if (firebase_uid) {
+    const now = new Date().toISOString();
+    await ddb.send(new PutCommand({
+      TableName: process.env.MERCHANTS_TABLE!,
+      Item: {
+        pk: `USER#${firebase_uid}`,
+        sk: `MERCHANT#${merchant_id}`,
+        merchant_id,
+        stripe_account_id: merchant_id,
+        firebase_uid,
+        created_at: now,
+        updated_at: now
+      }
+    }));
+  }
   
   // Audit successful OAuth connection
   await createAuditLog({

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -7,13 +7,33 @@ const CASES = process.env.CASES_TABLE!;
 export async function putMerchant(m:any){
   // Use stripe_account_id as the primary key for consistency
   const merchant_id = m.stripe_account_id || m.merchant_id;
+  if (!merchant_id) {
+    throw new Error("putMerchant requires a merchant_id or stripe_account_id");
+  }
+
+  const pk = `MERCHANT#${merchant_id}`;
+
+  // Fetch existing record so we don't blow away previously stored fields
+  let existing: Record<string, any> | undefined;
+  try {
+    const current = await ddb.send(new GetCommand({ TableName: MERCHANTS, Key: { pk } }));
+    existing = current.Item as Record<string, any> | undefined;
+  } catch (error) {
+    console.error('Failed to load existing merchant record', { merchant_id, error });
+  }
+
+  const now = new Date().toISOString();
+
   const item = {
-    pk: `MERCHANT#${merchant_id}`,
-    merchant_id: merchant_id,
-    stripe_account_id: merchant_id, // Ensure both fields are set
+    ...existing,
     ...m,
-    created_at: m.created_at || new Date().toISOString()
+    pk,
+    merchant_id: existing?.merchant_id || merchant_id,
+    stripe_account_id: existing?.stripe_account_id || merchant_id,
+    created_at: existing?.created_at || m.created_at || now,
+    updated_at: now
   };
+
   await ddb.send(new PutCommand({ TableName: MERCHANTS, Item: item }));
 }
 


### PR DESCRIPTION
## Summary
- ensure putMerchant merges updates with existing records so follow-up writes don't drop OAuth credentials
- capture firebase_uid when persisting the USER#/MERCHANT# relationship for authenticated lookups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68decfb16c60832f94ec6f333a003fe8