### PR TITLE
Add fraud warning flag to EvidencePackage

### DIFF
--- a/src/ce3-engine/evidenceBundler.ts
+++ b/src/ce3-engine/evidenceBundler.ts
@@ -11,6 +11,7 @@ export interface EvidencePackage {
   narrative: string;
   estimatedFields: EstimatedField[];
   submissionReady: boolean;
+  fraudWarning?: boolean;
 }
 
 export interface SupportingDocument {
@@ -84,7 +85,8 @@ export class EvidenceBundler {
       supportingDocuments,
       narrative,
       estimatedFields,
-      submissionReady: this.isSubmissionReady(evidence, dispute.reason)
+      submissionReady: this.isSubmissionReady(evidence, dispute.reason),
+      fraudWarning: false
     };
   }
 


### PR DESCRIPTION
## Summary
- extend the EvidencePackage type with an optional fraudWarning flag so downstream handlers can safely set it
- initialize assembled evidence packages with a default fraudWarning value

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dec81e2768832fb6b77f54acbcff10